### PR TITLE
Switch testpr linux-aarch64 to use public ubuntu-24.04-arm machines instead of cirun

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -14,7 +14,7 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux-64
-          - os: cirun-linux-aarch64--${{ github.run_id }}
+          - os: ubuntu-24.04-arm
             platform: linux-aarch64
           - os: macos-13
             platform: osx-64


### PR DESCRIPTION
After https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ we can use GitHub Actions also for native builds on `linux-aarch64`.