### PR TITLE
Added gripper_controllers for osx_arm64

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -6,3 +6,7 @@ rviz_common:
   build_number: 3
 tinyxml2_vendor:
   build_number: 3
+moveit_servo:
+  build_number: 3
+ros2_controllers:
+  build_number: 3

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -25,7 +25,6 @@ packages_skip_by_deps:
   - rttest
   - tlsf
   - tlsf_cpp
-  - gripper_controllers
 
 packages_remove_from_deps:
   - cartographer
@@ -33,7 +32,6 @@ packages_remove_from_deps:
   - rttest
   - tlsf
   - tlsf_cpp
-  - gripper_controllers
 
 skip_existing:
   # - output
@@ -91,6 +89,8 @@ packages_select_by_deps:
   - rmw_zenoh_cpp
 
   - flex_sync
+  - gripper_controllers
+
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -25,7 +25,6 @@ packages_skip_by_deps:
   - rttest
   - tlsf
   - tlsf_cpp
-  - gripper_controllers
 
 packages_remove_from_deps:
   - cartographer
@@ -33,7 +32,6 @@ packages_remove_from_deps:
   - rttest
   - tlsf
   - tlsf_cpp
-  - gripper_controllers
 
 skip_existing:
   # - output
@@ -91,6 +89,7 @@ packages_select_by_deps:
   - rmw_zenoh_cpp
 
   - flex_sync
+  - gripper_controllers
 
 
 patch_dir: patch


### PR DESCRIPTION
I'm unsure why the package was excluded from osx, but I ran `pixi run build` and all seems to work. 
In ros-humble there is a comment that it doesn't work for Mac and Windows (https://github.com/RoboStack/ros-humble/blob/e9557aa1a82f7434f6203c2f8d18aafb43a42884/vinca_osx_arm64.yaml#L39) but it seems this is no longer the case.

I cannot test with intel hardware so adding just for Apple silicon.