### PR TITLE
feat: add support for rosbridge and ament_cmake_mypy

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -82,5 +82,8 @@ packages_select_by_deps:
 
   - flex_sync
 
+  - ament_cmake_mypy
+  - rosbridge_suite
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -82,6 +82,9 @@ packages_select_by_deps:
 
   - flex_sync
 
+  - ament_cmake_mypy
+  - rosbridge_suite
+
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -91,6 +91,9 @@ packages_select_by_deps:
   - flex_sync
   - gripper_controllers
 
+  - ament_cmake_mypy
+  - rosbridge_suite
+
 
 
 patch_dir: patch

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -40,6 +40,7 @@ skip_existing:
 packages_select_by_deps:
   - ament_cmake_core
   - ament_cmake_catch2
+  - ament_cmake_mypy
 
   - desktop
   - ros_base
@@ -90,6 +91,8 @@ packages_select_by_deps:
 
   - flex_sync
   - gripper_controllers
+
+  - rosbridge_suite
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -93,6 +93,9 @@ packages_select_by_deps:
   - rmw_zenoh_cpp
 
   - flex_sync
+  
+  - ament_cmake_mypy
+  - rosbridge_suite
 
 
 patch_dir: patch


### PR DESCRIPTION
Adding support for rosbridge_suite and ament_cmake_mypy. Build completed without errors.
Because I currently don't have other OSes, so I'm only adding support for arm64 Macs.

While running `pixi run build`, it gives me following warnings: 
![截圖 2025-02-12 上午10 32 23](https://github.com/user-attachments/assets/fe8943a8-890c-4212-9631-d02d38b6bc16)

Is this a bad sign?