### PR TITLE
feat: add ros2 socketcan and its messages

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -94,5 +94,9 @@ packages_select_by_deps:
 
   - lanelet2
 
+  - can_msgs
+  - ros2_socketcan_msgs
+  - ros2_socketcan
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -94,5 +94,9 @@ packages_select_by_deps:
 
   - lanelet2
 
+  - can_msgs
+  - ros2_socketcan_msgs
+  - ros2_socketcan
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -103,5 +103,8 @@ packages_select_by_deps:
 
   - lanelet2
 
+  - can_msgs
+  - ros2_socketcan_msgs
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -103,5 +103,8 @@ packages_select_by_deps:
 
   - lanelet2
 
+  - can_msgs
+  - ros2_socketcan_msgs
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -104,6 +104,9 @@ packages_select_by_deps:
 
   - lanelet2
 
+  - can_msgs
+  - ros2_socketcan_msgs
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
 


### PR DESCRIPTION
`ros2_scoketcan` only supports linux platform because it utilizes `<linux/can>`.