### PR TITLE
Remove check for .yaml modification before recipe generated in testpr CI job and fix testpr job

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -1,8 +1,6 @@
 on:
   pull_request:
-    paths:
-      - '*.yml'
-      - '*.yaml'
+  workflow_dispatch:
 
 env:
   ROS_VERSION: 2

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -56,26 +56,9 @@ jobs:
         rm -rf /c/Strawberry
         rm -rf "/c/Program Files (x86)/Windows Kits/10/Include/10.0.17763.0/"
 
-    - name: Check what files have changed
-      id: filecheck
-      shell: bash -l {0}
-      run: |
-        git fetch origin main
-        # continue on error
-        set +e
-        git diff --exit-code --name-only origin/main -- vinca_linux_64.yaml > /dev/null
-        echo "::set-output name=LINUX_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_linux_aarch64.yaml > /dev/null
-        echo "::set-output name=LINUX_AARCH_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_osx.yaml > /dev/null
-        echo "::set-output name=OSX_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_osx_arm64.yaml > /dev/null
-        echo "::set-output name=OSX_ARM_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_win.yaml > /dev/null
-        echo "::set-output name=WIN_YAML_CHANGED::${?}"
     - name: Generate recipes for linux-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.LINUX_YAML_CHANGED == 1 && matrix.platform == 'linux-64'
+      if: matrix.platform == 'linux-64'
       run: |
         cp vinca_linux_64.yaml vinca.yaml
         mkdir -p recipes
@@ -83,7 +66,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for linux-aarch64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.LINUX_AARCH_YAML_CHANGED == 1 && matrix.platform == 'linux-aarch64'
+      if: matrix.platform == 'linux-aarch64'
       run: |
         cp vinca_linux_aarch64.yaml vinca.yaml
         mkdir -p recipes
@@ -91,7 +74,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for osx-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.OSX_YAML_CHANGED == 1 && matrix.platform == 'osx-64'
+      if: matrix.platform == 'osx-64'
       run: |
         cp vinca_osx.yaml vinca.yaml
         mkdir -p recipes
@@ -99,7 +82,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for osx-arm64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.OSX_ARM_YAML_CHANGED == 1 && matrix.platform == 'osx-arm64'
+      if: matrix.platform == 'osx-arm64'
       run: |
         cp vinca_osx_arm64.yaml vinca.yaml
         mkdir -p recipes
@@ -107,7 +90,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for win-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.WIN_YAML_CHANGED == 1 && matrix.platform == 'win-64'
+      if: matrix.platform == 'win-64'
       run: |
         # Workaround for problem related to long paths
         echo "CONDA_BLD_PATH=C:\\bld\\" >> $GITHUB_ENV
@@ -126,31 +109,31 @@ jobs:
         echo "::set-output name=RECIPE_CREATED::${?}"
     - name: Build recipes for linux-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.LINUX_YAML_CHANGED == 1 && matrix.platform == 'linux-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
     - name: Build recipes for linux-aarch64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.LINUX_AARCH_YAML_CHANGED == 1 && matrix.platform == 'linux-aarch64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-aarch64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
     - name: Build recipes for osx-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.OSX_YAML_CHANGED == 1 && matrix.platform == 'osx-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
     - name: Build recipes for osx-arm64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.OSX_ARM_YAML_CHANGED == 1 && matrix.platform == 'osx-arm64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-arm64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
     - name: Build recipes for win-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.WIN_YAML_CHANGED == 1 && matrix.platform == 'win-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'win-64'
       run: |
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform win-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform win-64 -m ./conda_build_config.yaml -c robostack-jazzy -c conda-forge --skip-existing

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     paths:
+      - '*.yml'
       - '*.yaml'
 
 env:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -11,6 +11,10 @@ pugixml:
 libopencv:
   - 4.11.0
 
+# Workaround for https://github.com/RoboStack/ros-jazzy/pull/40#issuecomment-2782226697
+cmake:
+  - 3.* 
+
 cdt_name:  # [linux]
   - conda  # [linux]
 


### PR DESCRIPTION
As we introduced several modifications in 2025, such as the use of rosdistro snapshot instead of always building the latest rosdistro, and the use of `pkg_additional_info.yaml` to bump the build number of packages that we want to rebuild, the check for `vinca_*.yaml` modification before running PR does not make a lot of sense. If a PR is not triggering the build of new packages, then the build step is super fast, and if instead a new recipe is triggered without us being aware of this, it is important that the PR CI catches the unintentional package generation.

xref: https://github.com/RoboStack/ros-humble/pull/277