### PR TITLE
Bump build number to 5 even in additional recipe

### DIFF
--- a/additional_recipes/ros-jazzy-octomap/recipe.yaml
+++ b/additional_recipes/ros-jazzy-octomap/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.10.0"
 
 build:
-  number: 0
+  number: 5
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom-headers/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom-headers/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.1.2"
 
 build:
-  number: 0
+  number: 5
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom-py/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom-py/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.2.1"
 
 build:
-  number: 0
+  number: 5
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "4.0.1"
 
 build:
-  number: 0
+  number: 5
 
 requirements:
   run:


### PR DESCRIPTION
This is something that we probably add in the full rebuild docs. This fixes the main CI failure:

~~~
2025-04-14T22:17:51.9255378Z Error: 
2025-04-14T22:17:51.9261013Z   × Failed to resolve dependencies: Cannot solve the request because of: ros-
2025-04-14T22:17:51.9262341Z   │ jazzy-urdfdom-headers * cannot be installed because there are no viable
2025-04-14T22:17:51.9262893Z   │ options:
2025-04-14T22:17:51.9263432Z   │ └─ ros-jazzy-urdfdom-headers 1.1.2 would require
2025-04-14T22:17:51.9263918Z   │    └─ python 3.11.* *_cpython, for which no candidates were found.
2025-04-14T22:17:51.9264345Z   │ 
2025-04-14T22:17:51.9264779Z   ╰─▶ Cannot solve the request because of: ros-jazzy-urdfdom-headers * cannot
2025-04-14T22:17:51.9265220Z       be installed because there are no viable options:
2025-04-14T22:17:51.9265706Z       └─ ros-jazzy-urdfdom-headers 1.1.2 would require
2025-04-14T22:17:51.9266675Z          └─ python 3.11.* *_cpython, for which no candidates were found.
~~~