### PR TITLE
Add dependency on generate-recipes for task build_additional_recipes

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -34,7 +34,7 @@ vinca = { git ="https://github.com/RoboStack/vinca.git", rev = "cbb8eba834ce3834
 [feature.beta.tasks]
 generate-recipes = { cmd = "vinca -m", depends-on = ["rename-file"] }
 remove-file = { cmd = "rm vinca.yaml; rm -rf recipes" }
-build_additional_recipes = { cmd = "rattler-build build --recipe-dir ./additional_recipes -m ./conda_build_config.yaml --skip-existing -c robostack-jazzy -c https://repo.prefix.dev/conda-forge" }
+build_additional_recipes = { cmd = "rattler-build build --recipe-dir ./additional_recipes -m ./conda_build_config.yaml --skip-existing -c robostack-jazzy -c https://repo.prefix.dev/conda-forge", depends-on = ["generate-recipes"] }
 build = { cmd = "rattler-build build --recipe-dir ./recipes -m ./conda_build_config.yaml -c robostack-jazzy -c https://repo.prefix.dev/conda-forge --skip-existing", depends-on = ["build_additional_recipes", "generate-recipes"] }
 build_one_package = { cmd = "cp ./patch/$PACKAGE.*patch ./recipes/$PACKAGE/patch/; rattler-build build --recipe ./recipes/$PACKAGE/recipe.yaml -m ./conda_build_config.yaml -c robostack-jazzy -c https://repo.prefix.dev/conda-forge", env = { PACKAGE = "ros-jazzy-ros-workspace" } }
 create_snapshot = { cmd = "vinca-snapshot -d jazzy -o rosdistro_snapshot.yaml" }


### PR DESCRIPTION
Fix https://github.com/RoboStack/ros-jazzy/issues/58 . An additional recipe has a symlink that points to a file that is generated by `generate-recipes`, so we must run `generate-recipes` before `build_additional_recipes`.

fyi @wep21 