### PR TITLE
Remake recipes folder after deleting it in pixi toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -33,7 +33,7 @@ vinca = { git ="https://github.com/RoboStack/vinca.git", rev = "cbb8eba834ce3834
 
 [feature.beta.tasks]
 generate-recipes = { cmd = "vinca -m", depends-on = ["rename-file"] }
-remove-file = { cmd = "rm vinca.yaml; rm -rf recipes" }
+remove-file = { cmd = "rm vinca.yaml; rm -rf recipes; mkdir recipes" }
 build_additional_recipes = { cmd = "rattler-build build --recipe-dir ./additional_recipes -m ./conda_build_config.yaml --skip-existing -c robostack-jazzy -c https://repo.prefix.dev/conda-forge", depends-on = ["generate-recipes"] }
 build = { cmd = "rattler-build build --recipe-dir ./recipes -m ./conda_build_config.yaml -c robostack-jazzy -c https://repo.prefix.dev/conda-forge --skip-existing", depends-on = ["build_additional_recipes", "generate-recipes"] }
 build_one_package = { cmd = "cp ./patch/$PACKAGE.*patch ./recipes/$PACKAGE/patch/; rattler-build build --recipe ./recipes/$PACKAGE/recipe.yaml -m ./conda_build_config.yaml -c robostack-jazzy -c https://repo.prefix.dev/conda-forge", env = { PACKAGE = "ros-jazzy-ros-workspace" } }


### PR DESCRIPTION
Closes https://github.com/RoboStack/ros-jazzy/issues/58

Currently, the remove-file task deletes the recipes folder and then later builds fail because there is no folder. So now we recreate empty recipes folder after deleting it.