### PR TITLE
Temporary disable moveit and ros2_control on Windows

### DIFF
--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -55,15 +55,16 @@ packages_select_by_deps:
   - simulation
   - desktop_full
 
-  - moveit
-  - moveit-planners-chomp
-  - moveit-servo
-  - moveit-visual-tools
+  # Temporary disabled as a workaround for the win issue in https://github.com/RoboStack/ros-jazzy/issues/61#issue-3128308287
+  # - moveit
+  # - moveit-planners-chomp
+  # - moveit-servo
+  # - moveit-visual-tools
 
-  - ros2_control
-  - ros2_controllers
-  - gz_ros2_control
-  - gz_ros2_control_demos
+  # - ros2_control
+  # - ros2_controllers
+  # - gz_ros2_control
+  # - gz_ros2_control_demos
 
   - rviz_visual_tools
 


### PR DESCRIPTION
As a workaround for "workflow file too large" , once some packages are built we can re-add them. See https://github.com/RoboStack/ros-jazzy/issues/61#issue-3128308287 .