### PR TITLE
Update additional recipes to use latest build_bumber and ros-distro-mutex version

### DIFF
--- a/additional_recipes/ros-jazzy-livox-ros-driver2/recipe.yaml
+++ b/additional_recipes/ros-jazzy-livox-ros-driver2/recipe.yaml
@@ -91,7 +91,7 @@ requirements:
     - ros-jazzy-ros-workspace
     - ros-jazzy-rosidl-default-generators
     - ros-jazzy-sensor-msgs
-    - ros2-distro-mutex 0.8.* jazzy_*
+    - ros2-distro-mutex 0.9.* jazzy_*
     - vtk-base
     - if: linux
       then:

--- a/additional_recipes/ros-jazzy-livox-ros-driver2/recipe.yaml
+++ b/additional_recipes/ros-jazzy-livox-ros-driver2/recipe.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   script: ${{ '$RECIPE_DIR/build_ament_cmake.sh' if unix else '%RECIPE_DIR%\\bld_ament_cmake.bat' }}
-  number: 6
+  number: 7
   skip:
     - not linux
   post_process:
@@ -111,7 +111,7 @@ requirements:
     - ros-jazzy-rclcpp-components
     - ros-jazzy-ros-workspace
     - ros-jazzy-sensor-msgs
-    - ros2-distro-mutex 0.8.* jazzy_*
+    - ros2-distro-mutex 0.9.* jazzy_*
     - vtk-base
     - if: osx and x86_64
       then:

--- a/additional_recipes/ros-jazzy-octomap/recipe.yaml
+++ b/additional_recipes/ros-jazzy-octomap/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.10.0"
 
 build:
-  number: 5
+  number: 7
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom-headers/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom-headers/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.1.2"
 
 build:
-  number: 5
+  number: 7
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom-py/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom-py/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "1.2.1"
 
 build:
-  number: 5
+  number: 7
 
 requirements:
   run:

--- a/additional_recipes/ros-jazzy-urdfdom/recipe.yaml
+++ b/additional_recipes/ros-jazzy-urdfdom/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "4.0.1"
 
 build:
-  number: 5
+  number: 7
 
 requirements:
   run:


### PR DESCRIPTION
Align additional recipes with https://github.com/RoboStack/ros-jazzy/pull/54 . This should fix https://github.com/RoboStack/ros-jazzy/issues/61#issuecomment-2966072401 .

fyi @wep21 @Tobias-Fischer 