### PR TITLE
Add the `ros-jazzy-geodesy` package

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -155,6 +155,9 @@ packages_select_by_deps:
   # IntelRealSense
   - librealsense2
 
+  # geodesy (required for many outdoors robotics packages)
+  - geodesy
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:


### PR DESCRIPTION
## Goal

Add the missing `geodesy` package into the `robostack-jazzy` channel.

## Description

We found that this package was missing from Jazzy when upgrading from Humble.

The Sooner Rover Team depends on this package directly.

## License

Happy to license this contribution into MIT/BSD0/CC0/etc. as needed; please let me know if the project has a license so I can state it formally! ;D