### PR TITLE
Rebuild robot_state_publisher after enabling CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -153,4 +153,8 @@ lanelet2_projection:
   additional_cmake_args: "-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF"
 lanelet2_python:
   additional_cmake_args: "-DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF"
+robot_state_publisher:
+  additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 # Everything after this comment needs to be removed on next full rebuild
+  build_number: 13
+

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 13
+# Reminder for next full rebuild, the next build number should be 14
 build_number: 12
 
 mutex_package:


### PR DESCRIPTION
Fix https://github.com/RoboStack/ros-jazzy/issues/131 . I have know idea how `robot_state_publisher.exe` works if the shared library does not export any symbol, but for sure this or something similar is required to fix https://github.com/RoboStack/ros-jazzy/issues/131 .