### PR TITLE
Add spacenav

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -168,8 +168,6 @@ packages_select_by_deps:
   - picknik_ament_copyright
 
   - rqt_robot_monitor
-  
-  - spacenav
 
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
@@ -232,6 +230,7 @@ packages_select_by_deps:
       - mavros
       - cloudini-lib
       - cloudini-ros
+      - spacenav
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml


### PR DESCRIPTION
This PR adds the spacenav package which is currently not available under jazzy.
This is my first contribution to this, so I hope I did everything correctly. It seemed a bit to easy.
I tested it locally (on a Linux machine) which resulted in the following output. It seemed to build fine, but delivers a warning (`warning Overdepending against ros-jazzy-rclcpp-components`). I am not sure why this warning is thrown and if it is relevant to fix it.
```

 ╭─ Build summary
 │
 │ ╭─ Build summary for recipe: ros-jazzy-spacenav-3.3.0-np2py312h2ed9cc7_14
 │ │ Artifact: /home/best_mr/git/ros-jazzy/output/linux-64/ros-jazzy-spacenav-3.3.0-np2py312h2ed9cc7_14.conda (166.52 KiB)
 │ │ Variant configuration (hash: np2py312h2ed9cc7_14):
 │ │ ╭──────────────────────┬────────────────────╮
 │ │ │ build_platform       ┆ "linux-64"         │
 │ │ │ c_compiler           ┆ "gcc"              │
 │ │ │ c_compiler_version   ┆ "14"               │
 │ │ │ c_stdlib             ┆ "sysroot"          │
 │ │ │ c_stdlib_version     ┆ "2.17"             │
 │ │ │ cmake                ┆ "3.*"              │
 │ │ │ cxx_compiler         ┆ "gxx"              │
 │ │ │ cxx_compiler_version ┆ "14"               │
 │ │ │ numpy                ┆ "2"                │
 │ │ │ python               ┆ "3.12.* *_cpython" │
 │ │ │ target_platform      ┆ "linux-64"         │
 │ │ ╰──────────────────────┴────────────────────╯
 │ │ 
 │ │ Build dependencies:
 │ │ ╭──────────────────────────┬─────────────────────────────┬──────────────┬──────────────────────┬─────────────┬─────────────╮
 │ │ │ Package                  ┆ Spec                        ┆ Version      ┆ Build                ┆ Channel     ┆        Size │
 │ │ ╞══════════════════════════╪═════════════════════════════╪══════════════╪══════════════════════╪═════════════╪═════════════╡
 │ │ │ cmake                    ┆ cmake 3.* (V)               ┆ 3.31.8       ┆ hc85cc9f_0           ┆ conda-forge ┆   20.02 MiB │
 │ │ │ coreutils                ┆ coreutils                   ┆ 9.5          ┆ hd590300_0           ┆ conda-forge ┆    2.87 MiB │
 │ │ │ cython                   ┆ cython                      ┆ 3.2.4        ┆ py312h68e6be4_0      ┆ conda-forge ┆    3.56 MiB │
 │ │ │ gcc_linux-64             ┆ gcc_linux-64 14.*           ┆ 14.3.0       ┆ h298d278_20          ┆ conda-forge ┆   28.24 KiB │
 │ │ │ git                      ┆ git                         ┆ 2.52.0       ┆ pl5321h6d3cee1_1     ┆ conda-forge ┆   10.94 MiB │
 │ │ │ git-lfs                  ┆ git-lfs                     ┆ 3.7.1        ┆ ha8f183a_1           ┆ conda-forge ┆    4.23 MiB │
 │ │ │ gxx_linux-64             ┆ gxx_linux-64 14.*           ┆ 14.3.0       ┆ h3c3a7a4_20          ┆ conda-forge ┆   26.84 KiB │
 │ │ │ make                     ┆ make                        ┆ 4.4.1        ┆ hb9d3cd8_2           ┆ conda-forge ┆  501.06 KiB │
 │ │ │ ninja                    ┆ ninja                       ┆ 1.13.2       ┆ h171cf75_0           ┆ conda-forge ┆  181.96 KiB │
 │ │ │ patch                    ┆ patch                       ┆ 2.8          ┆ hb03c661_1002        ┆ conda-forge ┆  114.47 KiB │
 │ │ │ python                   ┆ python 3.12.* *_cpython (V) ┆ 3.12.12      ┆ hd63d673_2_cpython   ┆ conda-forge ┆   30.00 MiB │
 │ │ │ setuptools               ┆ setuptools                  ┆ 82.0.0       ┆ pyh332efcf_0         ┆ conda-forge ┆  622.56 KiB │
 │ │ │ sysroot_linux-64         ┆ sysroot_linux-64 2.17.*     ┆ 2.17         ┆ h0157908_18          ┆ conda-forge ┆   14.46 MiB │
 │ │ │ _libgcc_mutex            ┆                             ┆ 0.1          ┆ conda_forge          ┆ conda-forge ┆    2.50 KiB │
 │ │ │ _openmp_mutex            ┆                             ┆ 4.5          ┆ 2_gnu                ┆ conda-forge ┆   23.07 KiB │
 │ │ │ binutils_impl_linux-64   ┆                             ┆ 2.45.1       ┆ default_hfdba357_101 ┆ conda-forge ┆    3.57 MiB │
 │ │ │ binutils_linux-64        ┆                             ┆ 2.45.1       ┆ default_h4852527_101 ┆ conda-forge ┆   35.21 KiB │
 │ │ │ bzip2                    ┆                             ┆ 1.0.8        ┆ hda65f42_8           ┆ conda-forge ┆  254.24 KiB │
 │ │ │ c-ares                   ┆                             ┆ 1.34.6       ┆ hb03c661_0           ┆ conda-forge ┆  203.01 KiB │
 │ │ │ ca-certificates          ┆                             ┆ 2026.1.4     ┆ hbd8a1cb_0           ┆ conda-forge ┆  143.08 KiB │
 │ │ │ gcc_impl_linux-64        ┆                             ┆ 14.3.0       ┆ hb1e0a52_17          ┆ conda-forge ┆   71.38 MiB │
 │ │ │ gxx_impl_linux-64        ┆                             ┆ 14.3.0       ┆ h2185e75_17          ┆ conda-forge ┆   14.54 MiB │
 │ │ │ icu                      ┆                             ┆ 78.2         ┆ h33c6efd_0           ┆ conda-forge ┆   12.14 MiB │
 │ │ │ kernel-headers_linux-64  ┆                             ┆ 3.10.0       ┆ he073ed8_18          ┆ conda-forge ┆  921.37 KiB │
 │ │ │ keyutils                 ┆                             ┆ 1.6.3        ┆ hb9d3cd8_0           ┆ conda-forge ┆  130.95 KiB │
 │ │ │ krb5                     ┆                             ┆ 1.22.2       ┆ ha1258a1_0           ┆ conda-forge ┆    1.32 MiB │
 │ │ │ ld_impl_linux-64         ┆                             ┆ 2.45.1       ┆ default_hbd61a6d_101 ┆ conda-forge ┆  708.50 KiB │
 │ │ │ libcurl                  ┆                             ┆ 8.18.0       ┆ hcf29cc6_1           ┆ conda-forge ┆  452.75 KiB │
 │ │ │ libedit                  ┆                             ┆ 3.1.20250104 ┆ pl5321h7949ede_0     ┆ conda-forge ┆  131.52 KiB │
 │ │ │ libev                    ┆                             ┆ 4.33         ┆ hd590300_2           ┆ conda-forge ┆  110.12 KiB │
 │ │ │ libexpat                 ┆                             ┆ 2.7.3        ┆ hecca717_0           ┆ conda-forge ┆   74.85 KiB │
 │ │ │ libffi                   ┆                             ┆ 3.5.2        ┆ h3435931_0           ┆ conda-forge ┆   57.22 KiB │
 │ │ │ libgcc                   ┆                             ┆ 15.2.0       ┆ he0feb66_17          ┆ conda-forge ┆ 1016.09 KiB │
 │ │ │ libgcc-devel_linux-64    ┆                             ┆ 14.3.0       ┆ hf649bbc_117         ┆ conda-forge ┆    2.94 MiB │
 │ │ │ libgcc-ng                ┆                             ┆ 15.2.0       ┆ h69a702a_17          ┆ conda-forge ┆   26.90 KiB │
 │ │ │ libgomp                  ┆                             ┆ 15.2.0       ┆ he0feb66_17          ┆ conda-forge ┆  589.19 KiB │
 │ │ │ libiconv                 ┆                             ┆ 1.18         ┆ h3b78370_2           ┆ conda-forge ┆  771.66 KiB │
 │ │ │ liblzma                  ┆                             ┆ 5.8.2        ┆ hb03c661_0           ┆ conda-forge ┆  110.55 KiB │
 │ │ │ libnghttp2               ┆                             ┆ 1.67.0       ┆ had1ee68_0           ┆ conda-forge ┆  650.98 KiB │
 │ │ │ libnsl                   ┆                             ┆ 2.0.1        ┆ hb9d3cd8_1           ┆ conda-forge ┆   32.94 KiB │
 │ │ │ libsanitizer             ┆                             ┆ 14.3.0       ┆ h8f1669f_17          ┆ conda-forge ┆    6.90 MiB │
 │ │ │ libsqlite                ┆                             ┆ 3.51.2       ┆ hf4e2dac_0           ┆ conda-forge ┆  920.71 KiB │
 │ │ │ libssh2                  ┆                             ┆ 1.11.1       ┆ hcf80075_0           ┆ conda-forge ┆  297.65 KiB │
 │ │ │ libstdcxx                ┆                             ┆ 15.2.0       ┆ h934c35e_17          ┆ conda-forge ┆    5.58 MiB │
 │ │ │ libstdcxx-devel_linux-64 ┆                             ┆ 14.3.0       ┆ h9f08a49_117         ┆ conda-forge ┆   19.55 MiB │
 │ │ │ libuuid                  ┆                             ┆ 2.41.3       ┆ h5347b49_0           ┆ conda-forge ┆   39.37 KiB │
 │ │ │ libuv                    ┆                             ┆ 1.51.0       ┆ hb03c661_1           ┆ conda-forge ┆  874.13 KiB │
 │ │ │ libxcrypt                ┆                             ┆ 4.4.36       ┆ hd590300_1           ┆ conda-forge ┆   98.04 KiB │
 │ │ │ libzlib                  ┆                             ┆ 1.3.1        ┆ hb9d3cd8_2           ┆ conda-forge ┆   59.53 KiB │
 │ │ │ ncurses                  ┆                             ┆ 6.5          ┆ h2d0b736_3           ┆ conda-forge ┆  870.74 KiB │
 │ │ │ openssl                  ┆                             ┆ 3.6.1        ┆ h35e630c_1           ┆ conda-forge ┆    3.02 MiB │
 │ │ │ pcre2                    ┆                             ┆ 10.47        ┆ haa7fec5_0           ┆ conda-forge ┆    1.17 MiB │
 │ │ │ perl                     ┆                             ┆ 5.32.1       ┆ 7_hd590300_perl5     ┆ conda-forge ┆   12.73 MiB │
 │ │ │ python_abi               ┆                             ┆ 3.12         ┆ 8_cp312              ┆ conda-forge ┆    6.79 KiB │
 │ │ │ readline                 ┆                             ┆ 8.3          ┆ h853b02a_0           ┆ conda-forge ┆  336.99 KiB │
 │ │ │ rhash                    ┆                             ┆ 1.4.6        ┆ hb9d3cd8_1           ┆ conda-forge ┆  189.23 KiB │
 │ │ │ tk                       ┆                             ┆ 8.6.13       ┆ noxft_h366c992_103   ┆ conda-forge ┆    3.15 MiB │
 │ │ │ tzdata                   ┆                             ┆ 2025c        ┆ hc9c84f9_1           ┆ conda-forge ┆  116.34 KiB │
 │ │ │ zstd                     ┆                             ┆ 1.5.7        ┆ hb78ec9c_6           ┆ conda-forge ┆  587.28 KiB │
 │ │ ╰──────────────────────────┴─────────────────────────────┴──────────────┴──────────────────────┴─────────────┴─────────────╯
 │ │ 
 │ │ Host dependencies:
 │ │ ╭──────────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────┬──────────────────────┬─────────────────┬─────────────╮
 │ │ │ Package                                          ┆ Spec                                         ┆ Version      ┆ Build                ┆ Channel         ┆        Size │
 │ │ ╞══════════════════════════════════════════════════╪══════════════════════════════════════════════╪══════════════╪══════════════════════╪═════════════════╪═════════════╡
 │ │ │ libgcc                                           ┆ libgcc >=14 (RE of [build: gcc_linux-64])    ┆ 15.2.0       ┆ he0feb66_17          ┆ conda-forge     ┆ 1016.09 KiB │
 │ │ │ libspnav                                         ┆ libspnav                                     ┆ 1.1          ┆ h4ab18f5_2           ┆ conda-forge     ┆   90.42 KiB │
 │ │ │ libstdcxx                                        ┆ libstdcxx >=14 (RE of [build: gxx_linux-64]) ┆ 15.2.0       ┆ h934c35e_17          ┆ conda-forge     ┆    5.58 MiB │
 │ │ │ numpy                                            ┆ numpy 2.* (V)                                ┆ 2.4.2        ┆ py312h33ff503_1      ┆ conda-forge     ┆    8.35 MiB │
 │ │ │ pip                                              ┆ pip                                          ┆ 26.0.1       ┆ pyh8b19718_0         ┆ conda-forge     ┆    1.13 MiB │
 │ │ │ pkg-config                                       ┆ pkg-config                                   ┆ 0.29.2       ┆ h4bc722e_1009        ┆ conda-forge     ┆  112.48 KiB │
 │ │ │ python                                           ┆ python 3.12.* *_cpython (V)                  ┆ 3.12.12      ┆ hd63d673_2_cpython   ┆ conda-forge     ┆   30.00 MiB │
 │ │ │ ros-jazzy-ament-cmake                            ┆ ros-jazzy-ament-cmake                        ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.77 KiB │
 │ │ │ ros-jazzy-ament-lint-auto                        ┆ ros-jazzy-ament-lint-auto                    ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.56 KiB │
 │ │ │ ros-jazzy-ament-lint-common                      ┆ ros-jazzy-ament-lint-common                  ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.82 KiB │
 │ │ │ ros-jazzy-geometry-msgs                          ┆ ros-jazzy-geometry-msgs                      ┆ 5.3.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  369.46 KiB │
 │ │ │ ros-jazzy-rclcpp                                 ┆ ros-jazzy-rclcpp                             ┆ 28.1.15      ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆    1.04 MiB │
 │ │ │ ros-jazzy-rclcpp-components                      ┆ ros-jazzy-rclcpp-components                  ┆ 28.1.15      ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  137.24 KiB │
 │ │ │ ros-jazzy-ros-environment                        ┆ ros-jazzy-ros-environment                    ┆ 4.2.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   20.93 KiB │
 │ │ │ ros-jazzy-ros-workspace                          ┆ ros-jazzy-ros-workspace                      ┆ 1.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   34.65 KiB │
 │ │ │ ros-jazzy-sensor-msgs                            ┆ ros-jazzy-sensor-msgs                        ┆ 5.3.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  533.38 KiB │
 │ │ │ ros2-distro-mutex                                ┆ ros2-distro-mutex 0.13.* jazzy_*             ┆ 0.13.0       ┆ jazzy_14             ┆ robostack-jazzy ┆    2.28 KiB │
 │ │ │ xorg-xorgproto                                   ┆ xorg-xorgproto                               ┆ 2025.1       ┆ hb03c661_0           ┆ conda-forge     ┆  556.65 KiB │
 │ │ │ _libgcc_mutex                                    ┆                                              ┆ 0.1          ┆ conda_forge          ┆ conda-forge     ┆    2.50 KiB │
 │ │ │ _openmp_mutex                                    ┆                                              ┆ 4.5          ┆ 2_gnu                ┆ conda-forge     ┆   23.07 KiB │
 │ │ │ argcomplete                                      ┆                                              ┆ 3.6.3        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   41.39 KiB │
 │ │ │ attr                                             ┆                                              ┆ 2.5.2        ┆ h39aace5_0           ┆ conda-forge     ┆   66.48 KiB │
 │ │ │ bzip2                                            ┆                                              ┆ 1.0.8        ┆ hda65f42_8           ┆ conda-forge     ┆  254.24 KiB │
 │ │ │ c-ares                                           ┆                                              ┆ 1.34.6       ┆ hb03c661_0           ┆ conda-forge     ┆  203.01 KiB │
 │ │ │ ca-certificates                                  ┆                                              ┆ 2026.1.4     ┆ hbd8a1cb_0           ┆ conda-forge     ┆  143.08 KiB │
 │ │ │ catkin_pkg                                       ┆                                              ┆ 1.1.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   52.84 KiB │
 │ │ │ cmake                                            ┆                                              ┆ 4.2.3        ┆ hc85cc9f_0           ┆ conda-forge     ┆   21.30 MiB │
 │ │ │ colorama                                         ┆                                              ┆ 0.4.6        ┆ pyhd8ed1ab_1         ┆ conda-forge     ┆   26.38 KiB │
 │ │ │ console_bridge                                   ┆                                              ┆ 1.0.2        ┆ h924138e_1           ┆ conda-forge     ┆   18.03 KiB │
 │ │ │ cppcheck                                         ┆                                              ┆ 2.18.3       ┆ py312h014360a_1      ┆ conda-forge     ┆    2.92 MiB │
 │ │ │ docutils                                         ┆                                              ┆ 0.22.4       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆  427.74 KiB │
 │ │ │ empy                                             ┆                                              ┆ 3.3.4        ┆ pyh9f0ad1d_1         ┆ conda-forge     ┆   39.27 KiB │
 │ │ │ exceptiongroup                                   ┆                                              ┆ 1.3.1        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   20.83 KiB │
 │ │ │ flake8                                           ┆                                              ┆ 7.3.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆  109.29 KiB │
 │ │ │ flake8-builtins                                  ┆                                              ┆ 3.1.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   19.04 KiB │
 │ │ │ flake8-comprehensions                            ┆                                              ┆ 3.17.0       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   13.72 KiB │
 │ │ │ flake8-docstrings                                ┆                                              ┆ 1.7.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   10.15 KiB │
 │ │ │ flake8-import-order                              ┆                                              ┆ 0.19.2       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   20.55 KiB │
 │ │ │ flake8-quotes                                    ┆                                              ┆ 3.4.0        ┆ pyhd8ed1ab_1         ┆ conda-forge     ┆   14.43 KiB │
 │ │ │ fmt                                              ┆                                              ┆ 12.1.0       ┆ hff5e90c_0           ┆ conda-forge     ┆  193.46 KiB │
 │ │ │ foonathan-memory                                 ┆                                              ┆ 0.7.3        ┆ h5888daf_1           ┆ conda-forge     ┆  221.81 KiB │
 │ │ │ gmock                                            ┆                                              ┆ 1.17.0       ┆ ha770c72_1           ┆ conda-forge     ┆    7.40 KiB │
 │ │ │ gtest                                            ┆                                              ┆ 1.17.0       ┆ h84d6215_1           ┆ conda-forge     ┆  406.85 KiB │
 │ │ │ icu                                              ┆                                              ┆ 78.2         ┆ h33c6efd_0           ┆ conda-forge     ┆   12.14 MiB │
 │ │ │ importlib-metadata                               ┆                                              ┆ 8.7.0        ┆ pyhe01879c_1         ┆ conda-forge     ┆   33.83 KiB │
 │ │ │ importlib_resources                              ┆                                              ┆ 6.5.2        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   32.99 KiB │
 │ │ │ iniconfig                                        ┆                                              ┆ 2.3.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   13.07 KiB │
 │ │ │ keyutils                                         ┆                                              ┆ 1.6.3        ┆ hb9d3cd8_0           ┆ conda-forge     ┆  130.95 KiB │
 │ │ │ krb5                                             ┆                                              ┆ 1.22.2       ┆ ha1258a1_0           ┆ conda-forge     ┆    1.32 MiB │
 │ │ │ lark-parser                                      ┆                                              ┆ 0.12.0       ┆ pyhd8ed1ab_1         ┆ conda-forge     ┆   84.12 KiB │
 │ │ │ ld_impl_linux-64                                 ┆                                              ┆ 2.45.1       ┆ default_hbd61a6d_101 ┆ conda-forge     ┆  708.50 KiB │
 │ │ │ libacl                                           ┆                                              ┆ 2.3.2        ┆ h0f662aa_0           ┆ conda-forge     ┆  108.01 KiB │
 │ │ │ libblas                                          ┆                                              ┆ 3.11.0       ┆ 5_h4a7cf45_openblas  ┆ conda-forge     ┆   17.79 KiB │
 │ │ │ libcblas                                         ┆                                              ┆ 3.11.0       ┆ 5_h0358290_openblas  ┆ conda-forge     ┆   17.77 KiB │
 │ │ │ libcurl                                          ┆                                              ┆ 8.18.0       ┆ hcf29cc6_1           ┆ conda-forge     ┆  452.75 KiB │
 │ │ │ libedit                                          ┆                                              ┆ 3.1.20250104 ┆ pl5321h7949ede_0     ┆ conda-forge     ┆  131.52 KiB │
 │ │ │ libev                                            ┆                                              ┆ 4.33         ┆ hd590300_2           ┆ conda-forge     ┆  110.12 KiB │
 │ │ │ libexpat                                         ┆                                              ┆ 2.7.3        ┆ hecca717_0           ┆ conda-forge     ┆   74.85 KiB │
 │ │ │ libffi                                           ┆                                              ┆ 3.5.2        ┆ h3435931_0           ┆ conda-forge     ┆   57.22 KiB │
 │ │ │ libgcc-ng                                        ┆                                              ┆ 15.2.0       ┆ h69a702a_17          ┆ conda-forge     ┆   26.90 KiB │
 │ │ │ libgfortran                                      ┆                                              ┆ 15.2.0       ┆ h69a702a_17          ┆ conda-forge     ┆   26.87 KiB │
 │ │ │ libgfortran5                                     ┆                                              ┆ 15.2.0       ┆ h68bc16d_17          ┆ conda-forge     ┆    2.37 MiB │
 │ │ │ libgomp                                          ┆                                              ┆ 15.2.0       ┆ he0feb66_17          ┆ conda-forge     ┆  589.19 KiB │
 │ │ │ libiconv                                         ┆                                              ┆ 1.18         ┆ h3b78370_2           ┆ conda-forge     ┆  771.66 KiB │
 │ │ │ liblapack                                        ┆                                              ┆ 3.11.0       ┆ 5_h47877c9_openblas  ┆ conda-forge     ┆   17.77 KiB │
 │ │ │ liblzma                                          ┆                                              ┆ 5.8.2        ┆ hb03c661_0           ┆ conda-forge     ┆  110.55 KiB │
 │ │ │ libnghttp2                                       ┆                                              ┆ 1.67.0       ┆ had1ee68_0           ┆ conda-forge     ┆  650.98 KiB │
 │ │ │ libnsl                                           ┆                                              ┆ 2.0.1        ┆ hb9d3cd8_1           ┆ conda-forge     ┆   32.94 KiB │
 │ │ │ libopenblas                                      ┆                                              ┆ 0.3.30       ┆ pthreads_h94d23a6_4  ┆ conda-forge     ┆    5.65 MiB │
 │ │ │ libsqlite                                        ┆                                              ┆ 3.51.2       ┆ hf4e2dac_0           ┆ conda-forge     ┆  920.71 KiB │
 │ │ │ libssh2                                          ┆                                              ┆ 1.11.1       ┆ hcf80075_0           ┆ conda-forge     ┆  297.65 KiB │
 │ │ │ libstdcxx-ng                                     ┆                                              ┆ 15.2.0       ┆ hdf11a46_17          ┆ conda-forge     ┆   26.93 KiB │
 │ │ │ liburcu                                          ┆                                              ┆ 0.14.0       ┆ hac33072_0           ┆ conda-forge     ┆  172.73 KiB │
 │ │ │ libuuid                                          ┆                                              ┆ 2.41.3       ┆ h5347b49_0           ┆ conda-forge     ┆   39.37 KiB │
 │ │ │ libuv                                            ┆                                              ┆ 1.51.0       ┆ hb03c661_1           ┆ conda-forge     ┆  874.13 KiB │
 │ │ │ libxcb                                           ┆                                              ┆ 1.17.0       ┆ h8a09558_0           ┆ conda-forge     ┆  386.61 KiB │
 │ │ │ libxcrypt                                        ┆                                              ┆ 4.4.36       ┆ hd590300_1           ┆ conda-forge     ┆   98.04 KiB │
 │ │ │ libxml2                                          ┆                                              ┆ 2.15.1       ┆ he237659_1           ┆ conda-forge     ┆   44.34 KiB │
 │ │ │ libxml2-16                                       ┆                                              ┆ 2.15.1       ┆ hca6bf5a_1           ┆ conda-forge     ┆  542.72 KiB │
 │ │ │ libzlib                                          ┆                                              ┆ 1.3.1        ┆ hb9d3cd8_2           ┆ conda-forge     ┆   59.53 KiB │
 │ │ │ lttng-ust                                        ┆                                              ┆ 2.13.9       ┆ hf5eda4c_0           ┆ conda-forge     ┆  366.56 KiB │
 │ │ │ mccabe                                           ┆                                              ┆ 0.7.0        ┆ pyhd8ed1ab_1         ┆ conda-forge     ┆   12.63 KiB │
 │ │ │ ncurses                                          ┆                                              ┆ 6.5          ┆ h2d0b736_3           ┆ conda-forge     ┆  870.74 KiB │
 │ │ │ openssl                                          ┆                                              ┆ 3.6.1        ┆ h35e630c_1           ┆ conda-forge     ┆    3.02 MiB │
 │ │ │ packaging                                        ┆                                              ┆ 26.0         ┆ pyhcf101f3_0         ┆ conda-forge     ┆   70.32 KiB │
 │ │ │ pcre                                             ┆                                              ┆ 8.45         ┆ h9c3ff4c_0           ┆ conda-forge     ┆  253.30 KiB │
 │ │ │ pluggy                                           ┆                                              ┆ 1.6.0        ┆ pyhf9edf01_1         ┆ conda-forge     ┆   25.27 KiB │
 │ │ │ pthread-stubs                                    ┆                                              ┆ 0.4          ┆ hb9d3cd8_1002        ┆ conda-forge     ┆    8.06 KiB │
 │ │ │ pycodestyle                                      ┆                                              ┆ 2.14.0       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   34.36 KiB │
 │ │ │ pydocstyle                                       ┆                                              ┆ 6.3.0        ┆ pyhd8ed1ab_1         ┆ conda-forge     ┆   39.29 KiB │
 │ │ │ pyflakes                                         ┆                                              ┆ 3.4.0        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   58.20 KiB │
 │ │ │ pygments                                         ┆                                              ┆ 2.19.2       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆  868.44 KiB │
 │ │ │ pyparsing                                        ┆                                              ┆ 3.3.2        ┆ pyhcf101f3_0         ┆ conda-forge     ┆  108.29 KiB │
 │ │ │ pytest                                           ┆                                              ┆ 9.0.2        ┆ pyhcf101f3_0         ┆ conda-forge     ┆  292.56 KiB │
 │ │ │ python-dateutil                                  ┆                                              ┆ 2.9.0.post0  ┆ pyhe01879c_2         ┆ conda-forge     ┆  227.84 KiB │
 │ │ │ python_abi                                       ┆                                              ┆ 3.12         ┆ 8_cp312              ┆ conda-forge     ┆    6.79 KiB │
 │ │ │ readline                                         ┆                                              ┆ 8.3          ┆ h853b02a_0           ┆ conda-forge     ┆  336.99 KiB │
 │ │ │ rhash                                            ┆                                              ┆ 1.4.6        ┆ hb9d3cd8_1           ┆ conda-forge     ┆  189.23 KiB │
 │ │ │ ros-jazzy-action-msgs                            ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  148.76 KiB │
 │ │ │ ros-jazzy-ament-cmake-copyright                  ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.24 KiB │
 │ │ │ ros-jazzy-ament-cmake-core                       ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   43.89 KiB │
 │ │ │ ros-jazzy-ament-cmake-cppcheck                   ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.83 KiB │
 │ │ │ ros-jazzy-ament-cmake-cpplint                    ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.85 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-definitions         ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.59 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-dependencies        ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.50 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-include-directories ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.01 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-interfaces          ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.20 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-libraries           ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.49 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-link-flags          ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.55 KiB │
 │ │ │ ros-jazzy-ament-cmake-export-targets             ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.31 KiB │
 │ │ │ ros-jazzy-ament-cmake-flake8                     ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.88 KiB │
 │ │ │ ros-jazzy-ament-cmake-gen-version-h              ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   24.24 KiB │
 │ │ │ ros-jazzy-ament-cmake-gmock                      ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   24.42 KiB │
 │ │ │ ros-jazzy-ament-cmake-gtest                      ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   24.18 KiB │
 │ │ │ ros-jazzy-ament-cmake-include-directories        ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.49 KiB │
 │ │ │ ros-jazzy-ament-cmake-libraries                  ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.17 KiB │
 │ │ │ ros-jazzy-ament-cmake-lint-cmake                 ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.94 KiB │
 │ │ │ ros-jazzy-ament-cmake-pep257                     ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.58 KiB │
 │ │ │ ros-jazzy-ament-cmake-pytest                     ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   24.27 KiB │
 │ │ │ ros-jazzy-ament-cmake-python                     ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.65 KiB │
 │ │ │ ros-jazzy-ament-cmake-ros                        ┆                                              ┆ 0.12.0       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   30.65 KiB │
 │ │ │ ros-jazzy-ament-cmake-target-dependencies        ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.17 KiB │
 │ │ │ ros-jazzy-ament-cmake-test                       ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   35.31 KiB │
 │ │ │ ros-jazzy-ament-cmake-uncrustify                 ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   23.16 KiB │
 │ │ │ ros-jazzy-ament-cmake-version                    ┆                                              ┆ 2.5.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   21.34 KiB │
 │ │ │ ros-jazzy-ament-cmake-xmllint                    ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.61 KiB │
 │ │ │ ros-jazzy-ament-copyright                        ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   65.06 KiB │
 │ │ │ ros-jazzy-ament-cppcheck                         ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   29.26 KiB │
 │ │ │ ros-jazzy-ament-cpplint                          ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  164.82 KiB │
 │ │ │ ros-jazzy-ament-flake8                           ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   27.74 KiB │
 │ │ │ ros-jazzy-ament-index-cpp                        ┆                                              ┆ 1.8.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   45.93 KiB │
 │ │ │ ros-jazzy-ament-index-python                     ┆                                              ┆ 1.8.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   29.04 KiB │
 │ │ │ ros-jazzy-ament-lint                             ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   17.90 KiB │
 │ │ │ ros-jazzy-ament-lint-cmake                       ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   38.62 KiB │
 │ │ │ ros-jazzy-ament-package                          ┆                                              ┆ 0.16.4       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   42.04 KiB │
 │ │ │ ros-jazzy-ament-pep257                           ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   26.47 KiB │
 │ │ │ ros-jazzy-ament-uncrustify                       ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   66.62 KiB │
 │ │ │ ros-jazzy-ament-xmllint                          ┆                                              ┆ 0.17.3       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   27.50 KiB │
 │ │ │ ros-jazzy-builtin-interfaces                     ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   78.14 KiB │
 │ │ │ ros-jazzy-class-loader                           ┆                                              ┆ 2.7.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   72.58 KiB │
 │ │ │ ros-jazzy-composition-interfaces                 ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  219.21 KiB │
 │ │ │ ros-jazzy-console-bridge-vendor                  ┆                                              ┆ 1.7.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   27.19 KiB │
 │ │ │ ros-jazzy-cyclonedds                             ┆                                              ┆ 0.10.5       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆    1.14 MiB │
 │ │ │ ros-jazzy-domain-coordinator                     ┆                                              ┆ 0.12.0       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   20.67 KiB │
 │ │ │ ros-jazzy-fastcdr                                ┆                                              ┆ 2.2.5        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   86.64 KiB │
 │ │ │ ros-jazzy-fastrtps                               ┆                                              ┆ 2.14.5       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆    4.09 MiB │
 │ │ │ ros-jazzy-fastrtps-cmake-module                  ┆                                              ┆ 3.6.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   26.93 KiB │
 │ │ │ ros-jazzy-foonathan-memory-vendor                ┆                                              ┆ 1.3.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   19.15 KiB │
 │ │ │ ros-jazzy-gmock-vendor                           ┆                                              ┆ 1.14.9000    ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  119.63 KiB │
 │ │ │ ros-jazzy-gtest-vendor                           ┆                                              ┆ 1.14.9000    ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  203.99 KiB │
 │ │ │ ros-jazzy-iceoryx-binding-c                      ┆                                              ┆ 2.0.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   90.87 KiB │
 │ │ │ ros-jazzy-iceoryx-hoofs                          ┆                                              ┆ 2.0.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  257.70 KiB │
 │ │ │ ros-jazzy-iceoryx-posh                           ┆                                              ┆ 2.0.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  560.43 KiB │
 │ │ │ ros-jazzy-libstatistics-collector                ┆                                              ┆ 1.7.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   57.28 KiB │
 │ │ │ ros-jazzy-libyaml-vendor                         ┆                                              ┆ 1.6.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   29.09 KiB │
 │ │ │ ros-jazzy-python-cmake-module                    ┆                                              ┆ 0.11.1       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   27.28 KiB │
 │ │ │ ros-jazzy-rcl                                    ┆                                              ┆ 9.2.8        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  196.90 KiB │
 │ │ │ ros-jazzy-rcl-interfaces                         ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  556.16 KiB │
 │ │ │ ros-jazzy-rcl-logging-interface                  ┆                                              ┆ 3.1.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   34.94 KiB │
 │ │ │ ros-jazzy-rcl-logging-spdlog                     ┆                                              ┆ 3.1.1        ┆ np2py312h918b84f_14  ┆ robostack-jazzy ┆   45.27 KiB │
 │ │ │ ros-jazzy-rcl-yaml-param-parser                  ┆                                              ┆ 9.2.8        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   50.68 KiB │
 │ │ │ ros-jazzy-rcpputils                              ┆                                              ┆ 2.11.2       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   78.83 KiB │
 │ │ │ ros-jazzy-rcutils                                ┆                                              ┆ 6.7.5        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  119.83 KiB │
 │ │ │ ros-jazzy-rmw                                    ┆                                              ┆ 7.3.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   95.02 KiB │
 │ │ │ ros-jazzy-rmw-connextdds                         ┆                                              ┆ 0.22.2       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   31.57 KiB │
 │ │ │ ros-jazzy-rmw-connextdds-common                  ┆                                              ┆ 0.22.2       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   52.92 KiB │
 │ │ │ ros-jazzy-rmw-cyclonedds-cpp                     ┆                                              ┆ 2.2.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  259.99 KiB │
 │ │ │ ros-jazzy-rmw-dds-common                         ┆                                              ┆ 3.1.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  174.28 KiB │
 │ │ │ ros-jazzy-rmw-fastrtps-cpp                       ┆                                              ┆ 8.4.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  156.49 KiB │
 │ │ │ ros-jazzy-rmw-fastrtps-dynamic-cpp               ┆                                              ┆ 8.4.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  183.17 KiB │
 │ │ │ ros-jazzy-rmw-fastrtps-shared-cpp                ┆                                              ┆ 8.4.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  226.71 KiB │
 │ │ │ ros-jazzy-rmw-implementation                     ┆                                              ┆ 2.15.6       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   53.28 KiB │
 │ │ │ ros-jazzy-rmw-implementation-cmake               ┆                                              ┆ 7.3.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   28.74 KiB │
 │ │ │ ros-jazzy-rosgraph-msgs                          ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   70.56 KiB │
 │ │ │ ros-jazzy-rosidl-adapter                         ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   62.15 KiB │
 │ │ │ ros-jazzy-rosidl-cli                             ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   41.87 KiB │
 │ │ │ ros-jazzy-rosidl-cmake                           ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   35.49 KiB │
 │ │ │ ros-jazzy-rosidl-core-runtime                    ┆                                              ┆ 0.2.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   30.73 KiB │
 │ │ │ ros-jazzy-rosidl-default-runtime                 ┆                                              ┆ 1.6.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   31.33 KiB │
 │ │ │ ros-jazzy-rosidl-dynamic-typesupport             ┆                                              ┆ 0.1.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   61.60 KiB │
 │ │ │ ros-jazzy-rosidl-dynamic-typesupport-fastrtps    ┆                                              ┆ 0.1.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   84.51 KiB │
 │ │ │ ros-jazzy-rosidl-generator-c                     ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   52.07 KiB │
 │ │ │ ros-jazzy-rosidl-generator-cpp                   ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   49.00 KiB │
 │ │ │ ros-jazzy-rosidl-generator-py                    ┆                                              ┆ 0.22.2       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   58.89 KiB │
 │ │ │ ros-jazzy-rosidl-generator-type-description      ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   47.78 KiB │
 │ │ │ ros-jazzy-rosidl-parser                          ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   58.96 KiB │
 │ │ │ ros-jazzy-rosidl-pycommon                        ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   24.78 KiB │
 │ │ │ ros-jazzy-rosidl-runtime-c                       ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   81.77 KiB │
 │ │ │ ros-jazzy-rosidl-runtime-cpp                     ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   40.11 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-c                   ┆                                              ┆ 3.2.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   50.10 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-cpp                 ┆                                              ┆ 3.2.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   49.19 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-fastrtps-c          ┆                                              ┆ 3.6.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   50.77 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-fastrtps-cpp        ┆                                              ┆ 3.6.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   52.79 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-interface           ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   28.69 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-introspection-c     ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   47.29 KiB │
 │ │ │ ros-jazzy-rosidl-typesupport-introspection-cpp   ┆                                              ┆ 4.6.7        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   47.51 KiB │
 │ │ │ ros-jazzy-rpyutils                               ┆                                              ┆ 0.4.2        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   25.84 KiB │
 │ │ │ ros-jazzy-rti-connext-dds-cmake-module           ┆                                              ┆ 0.22.2       ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   30.95 KiB │
 │ │ │ ros-jazzy-service-msgs                           ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   78.91 KiB │
 │ │ │ ros-jazzy-spdlog-vendor                          ┆                                              ┆ 1.6.1        ┆ np2py312h918b84f_14  ┆ robostack-jazzy ┆   26.80 KiB │
 │ │ │ ros-jazzy-statistics-msgs                        ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  106.68 KiB │
 │ │ │ ros-jazzy-std-msgs                               ┆                                              ┆ 5.3.6        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  332.14 KiB │
 │ │ │ ros-jazzy-tracetools                             ┆                                              ┆ 8.2.4        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   71.29 KiB │
 │ │ │ ros-jazzy-type-description-interfaces            ┆                                              ┆ 2.0.3        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆  226.91 KiB │
 │ │ │ ros-jazzy-uncrustify-vendor                      ┆                                              ┆ 3.0.1        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   22.71 KiB │
 │ │ │ ros-jazzy-unique-identifier-msgs                 ┆                                              ┆ 2.5.0        ┆ np2py312h2ed9cc7_14  ┆ robostack-jazzy ┆   72.33 KiB │
 │ │ │ setuptools                                       ┆                                              ┆ 82.0.0       ┆ pyh332efcf_0         ┆ conda-forge     ┆  622.56 KiB │
 │ │ │ six                                              ┆                                              ┆ 1.17.0       ┆ pyhe01879c_1         ┆ conda-forge     ┆   18.02 KiB │
 │ │ │ snowballstemmer                                  ┆                                              ┆ 3.0.1        ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   71.30 KiB │
 │ │ │ spdlog                                           ┆                                              ┆ 1.17.0       ┆ hab81395_1           ┆ conda-forge     ┆  192.07 KiB │
 │ │ │ tinyxml2                                         ┆                                              ┆ 11.0.0       ┆ h3f2d84a_0           ┆ conda-forge     ┆  128.27 KiB │
 │ │ │ tk                                               ┆                                              ┆ 8.6.13       ┆ noxft_h366c992_103   ┆ conda-forge     ┆    3.15 MiB │
 │ │ │ tomli                                            ┆                                              ┆ 2.4.0        ┆ pyhcf101f3_0         ┆ conda-forge     ┆   20.95 KiB │
 │ │ │ typing_extensions                                ┆                                              ┆ 4.15.0       ┆ pyhcf101f3_0         ┆ conda-forge     ┆   50.48 KiB │
 │ │ │ tzdata                                           ┆                                              ┆ 2025c        ┆ hc9c84f9_1           ┆ conda-forge     ┆  116.34 KiB │
 │ │ │ uncrustify                                       ┆                                              ┆ 0.81.0       ┆ h5888daf_0           ┆ conda-forge     ┆  635.08 KiB │
 │ │ │ wheel                                            ┆                                              ┆ 0.46.3       ┆ pyhd8ed1ab_0         ┆ conda-forge     ┆   31.11 KiB │
 │ │ │ xorg-libx11                                      ┆                                              ┆ 1.8.13       ┆ he1eb515_0           ┆ conda-forge     ┆  819.97 KiB │
 │ │ │ xorg-libxau                                      ┆                                              ┆ 1.0.12       ┆ hb03c661_1           ┆ conda-forge     ┆   14.96 KiB │
 │ │ │ xorg-libxdmcp                                    ┆                                              ┆ 1.1.5        ┆ hb03c661_1           ┆ conda-forge     ┆   20.11 KiB │
 │ │ │ yaml                                             ┆                                              ┆ 0.2.5        ┆ h280c20c_3           ┆ conda-forge     ┆   83.19 KiB │
 │ │ │ yaml-cpp                                         ┆                                              ┆ 0.8.0        ┆ h3f2d84a_0           ┆ conda-forge     ┆  218.29 KiB │
 │ │ │ zipp                                             ┆                                              ┆ 3.23.0       ┆ pyhcf101f3_1         ┆ conda-forge     ┆   23.63 KiB │
 │ │ │ zstd                                             ┆                                              ┆ 1.5.7        ┆ hb78ec9c_6           ┆ conda-forge     ┆  587.28 KiB │
 │ │ ╰──────────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────┴──────────────────────┴─────────────────┴─────────────╯
 │ │ 
 │ │ Run dependencies:
 │ │ ╭─────────────────────────────┬──────────────────────────────────────────────────────╮
 │ │ │ Name                        ┆ Spec                                                 │
 │ │ ╞═════════════════════════════╪══════════════════════════════════════════════════════╡
 │ │ │ Run dependencies            ┆                                                      │
 │ │ │ libspnav                    ┆                                                      │
 │ │ │ python                      ┆                                                      │
 │ │ │ ros-jazzy-geometry-msgs     ┆                                                      │
 │ │ │ ros-jazzy-rclcpp            ┆                                                      │
 │ │ │ ros-jazzy-rclcpp-components ┆                                                      │
 │ │ │ ros-jazzy-ros-workspace     ┆                                                      │
 │ │ │ ros-jazzy-sensor-msgs       ┆                                                      │
 │ │ │ ros2-distro-mutex           ┆ 0.13.* jazzy_*                                       │
 │ │ │ xorg-xorgproto              ┆                                                      │
 │ │ │ __glibc                     ┆ >=2.17,<3.0.a0 (RE of [build: sysroot_linux-64])     │
 │ │ │ libgcc                      ┆ >=14 (RE of [build: gcc_linux-64])                   │
 │ │ │ libstdcxx                   ┆ >=14 (RE of [build: gxx_linux-64])                   │
 │ │ │ libgcc                      ┆ >=14 (RE of [build: gxx_linux-64])                   │
 │ │ │ numpy                       ┆ >=1.23,<3 (RE of [host: numpy])                      │
 │ │ │ python_abi                  ┆ 3.12.* *_cp312 (RE of [host: python])                │
 │ │ │ ros2-distro-mutex           ┆ >=0.13.0,<0.14.0a0 (RE of [host: ros2-distro-mutex]) │
 │ │ ╰─────────────────────────────┴──────────────────────────────────────────────────────╯
 │ │ 
 │ │ ⚠ warning Warnings:
 │ │ ⚠ warning Overdepending against ros-jazzy-rclcpp-components
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 0 seconds)
```