### PR TITLE
Fix urdfdom mapping to avoid ur-description solve conflict

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -28,6 +28,8 @@ urdfdom:
     # jazzy is on 4.0.2, but we stick to 4.0.1 for compat
     # with the rest of conda-forge
     override_version: '4.0.1'
+ur_description:
+  build_number: 17
 cartographer:
   generate_dummy_package_with_run_deps:
     dep_name: cartographer

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -503,11 +503,11 @@ libudev-dev:
     osx: [libusb]
     win64: [libusb]
 liburdfdom-dev:
-  robostack: [urdfdom]
+  robostack: [ros-jazzy-urdfdom]
 liburdfdom-headers-dev:
-  robostack: [urdfdom_headers]
+  robostack: [ros-jazzy-urdfdom-headers]
 liburdfdom-tools:
-  robostack: [urdfdom]
+  robostack: [ros-jazzy-urdfdom]
 libusb-1.0:
   robostack:
     linux: [libusb, libudev]


### PR DESCRIPTION
`ur_description` resolves to urdfdom higher than the one pinned in `ros-jazzy-urdfdom`. This PR tries to map them to the ros-pinned dependencies so it aligns with the distro mutex and avoids conflict.

Related: https://github.com/RoboStack/ros-jazzy/pull/161