### PR TITLE
Add canopen to build

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -53,7 +53,7 @@ c_stdlib:
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
 c_stdlib_version:              # [unix]
-  - 2.17                       # [linux]
+  - 2.28                       # [linux]
   - 10.13                      # [osx and x86_64]
   - 11.0                       # [osx and arm64]
 cxx_compiler:

--- a/patch/ros-jazzy-lely-core-libraries.patch
+++ b/patch/ros-jazzy-lely-core-libraries.patch
@@ -1,0 +1,55 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 29506fe4..6fbfc480 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,8 +8,8 @@ include(ExternalProject)
+ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
+   #--Download step--------------
+   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/upstream
+-  INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"  # Installation prefix
+-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
++  INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lely_install"  # Installation prefix
++  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/lely
+   GIT_REPOSITORY https://gitlab.com/lely_industries/lely-core.git
+   GIT_TAG fb735b79cab5f0cdda45bc5087414d405ef8f3ab
+   TIMEOUT 60
+@@ -21,13 +21,13 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
+   CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR>
+   COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-cython --disable-doc --disable-tests --disable-static --disable-diag
+   #BUILD STEP execute make
+-  BUILD_COMMAND $(MAKE) -C ${CMAKE_CURRENT_BINARY_DIR}/build
++  BUILD_COMMAND make -j
+   #INSTALL STEP do nothing as we install in main
+-  INSTALL_COMMAND ""
++  INSTALL_COMMAND make install VERBOSE=1
+ )
+ 
+ #INSTALL lely_core_libraries - execute make install
+-install(CODE "execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} install VERBOSE=1 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build)")
++#install(CODE "execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} install VERBOSE=1 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build)")
+ 
+ set(lely_core_cmake_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ include("cmake/lely_core_libraries-extras.cmake" NO_POLICY_SCOPE)
+@@ -46,6 +46,22 @@ install(
+     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/
+     USE_SOURCE_PERMISSIONS)
+ 
++install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lely_install/bin/
++    USE_SOURCE_PERMISSIONS
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
++)
++
++install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lely_install/include/lely/
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/lely
++)
++
++install(
++    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lely_install/lib/
++    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
++)
++
+ ament_export_include_directories(include)
+ ament_export_libraries(lely-can lely-co lely-coapp lely-ev lely-io2 lely-libc lely-tap lely-util)
+ ament_package(

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -169,6 +169,8 @@ packages_select_by_deps:
 
   - rqt_robot_monitor
 
+  - canopen
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -169,8 +169,6 @@ packages_select_by_deps:
 
   - rqt_robot_monitor
 
-  - canopen
-
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:
@@ -199,6 +197,7 @@ packages_select_by_deps:
       - plansys2_tests
       - plansys2_tools
       - popf
+      - canopen
   
   # These packages are currently only build on Linux, but they currently only build on
   # Linux as trying to build them in the past on macos or Windows resulted in errors

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -198,6 +198,11 @@ packages_select_by_deps:
       - plansys2_tools
       - popf
       - canopen
+      - canopen-ros2-control
+      - canopen-ros2-controllers
+      - canopen-master-driver
+      - canopen-fake-slaves
+      - canopen-utils
   
   # These packages are currently only build on Linux, but they currently only build on
   # Linux as trying to build them in the past on macos or Windows resulted in errors


### PR DESCRIPTION
This PR adds building for the canopen packages, including its dependency on ros-jazzy-lely-core-libraries.
Since lely-core-libraries relies on newer linux CAN header files, the c_stdlib_version needs to be higher for this package. I tried to add 
```
lely_core_libraries:
  add_build: ["sysroot_linux-64 >= 2.28"]

```
to the dependencies.yaml, however this does not work because then the depency will be listed two times in the generated reciepe.yaml. I am not sure if this is really a change that you want to merge. Feel free to reject this PR. In that case people can still find it here if they want to build lely-core-libraries on their own.
The patch file is also ugly. I spend a lot of time debugging the build of lely-core-libraries and this was the best I could come up with. It first installs everthing to an intermediate folder and then installs it from there to the final destination.