### PR TITLE
Add mujoco-vendor and mujoco-ros2-control support using libmujoco from conda-forge

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -75,3 +75,5 @@ libhwloc:
 urdfdom:
   - '4.0'
 
+libmujoco:
+  - 3.5.0

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -266,3 +266,5 @@ openvdb_vendor:
   add_host: ["openvdb"]
 spatio_temporal_voxel_layer:
   add_host: ["${{ 'libgl-devel' if linux }}", "${{ 'libopengl-devel' if linux }}"]
+mujoco_vendor:
+  add_host: ["libmujoco"]

--- a/patch/ros-jazzy-mujoco-ros2-control.patch
+++ b/patch/ros-jazzy-mujoco-ros2-control.patch
@@ -1,0 +1,87 @@
+diff --git a/mujoco_ros2_control/CMakeLists.txt b/mujoco_ros2_control/CMakeLists.txt
+index cd99b4c..c3d2cd2 100644
+--- a/mujoco_ros2_control/CMakeLists.txt
++++ b/mujoco_ros2_control/CMakeLists.txt
+@@ -41,7 +41,8 @@ else()
+   include(DownloadMujoco)
+ endif()
+ 
+-# Fetch lodepng dependency.
++# Fetch lodepng dependency, if not available
++find_package(lodepng QUIET)
+ if(NOT TARGET lodepng)
+   include(FetchContent)
+   FetchContent_Declare(
+@@ -62,6 +63,10 @@ if(NOT TARGET lodepng)
+     target_link_options(lodepng PRIVATE ${MUJOCO_MACOS_LINK_OPTIONS})
+     target_include_directories(lodepng PUBLIC ${lodepng_SOURCE_DIR})
+   endif()
++  install(TARGETS lodepng
++    LIBRARY DESTINATION lib
++    ARCHIVE DESTINATION lib
++  )
+ endif()
+ 
+ # We don't care about warnings from the external sources
+@@ -73,6 +78,7 @@ set(MUJOCO_SILENCE_COMPILER_WARNINGS
+ )
+ 
+ # Build MuJoCo's simulate application and make it available for linking
++if(NOT TARGET mujoco::libmujoco_simulate)
+ add_library(platform_ui_adapter OBJECT)
+ set_target_properties(platform_ui_adapter PROPERTIES
+   POSITION_INDEPENDENT_CODE ON
+@@ -88,7 +94,7 @@ target_compile_options(platform_ui_adapter PRIVATE ${MUJOCO_SILENCE_COMPILER_WAR
+ add_library(mujoco::platform_ui_adapter ALIAS platform_ui_adapter)
+ 
+ add_library(libsimulate STATIC $<TARGET_OBJECTS:platform_ui_adapter>)
+-add_library(mujoco::libsimulate ALIAS libsimulate)
++add_library(mujoco::libmujoco_simulate ALIAS libsimulate)
+ set_target_properties(libsimulate PROPERTIES
+   OUTPUT_NAME simulate
+   POSITION_INDEPENDENT_CODE ON
+@@ -105,6 +111,11 @@ target_compile_options(libsimulate PRIVATE ${MUJOCO_SILENCE_COMPILER_WARNINGS})
+ # We set these after creating the targets to avoid propagating them to other third-party targets
+ set_compiler_options()
+ export_windows_symbols()
++install(TARGETS libsimulate
++  LIBRARY DESTINATION lib
++  ARCHIVE DESTINATION lib
++)
++endif()
+ 
+ # MuJoCo ROS 2 control system interface (this package)
+ add_library(mujoco_ros2_control SHARED
+@@ -142,7 +153,7 @@ PUBLIC
+   control_toolbox::control_toolbox
+   Eigen3::Eigen
+ PRIVATE
+-  mujoco::libsimulate
++  mujoco::libmujoco_simulate
+   Threads::Threads
+   lodepng
+   glfw
+@@ -167,11 +178,6 @@ install(TARGETS mujoco_ros2_control ${MUJOCO_EXPORT_TARGETS}
+   RUNTIME DESTINATION bin
+ )
+ 
+-# Install runtime deps
+-install(TARGETS libsimulate lodepng
+-  LIBRARY DESTINATION lib
+-  ARCHIVE DESTINATION lib
+-)
+ install(DIRECTORY include/ DESTINATION include)
+ 
+ # Install the ROS 2 control node
+diff --git a/mujoco_ros2_control/src/mujoco_system_interface.cpp b/mujoco_ros2_control/src/mujoco_system_interface.cpp
+index 934866e..b5d11b5 100644
+--- a/mujoco_ros2_control/src/mujoco_system_interface.cpp
++++ b/mujoco_ros2_control/src/mujoco_system_interface.cpp
+@@ -37,6 +37,7 @@
+ #include <stdexcept>
+ #include <string>
+ #include <thread>
++#include <unistd.h>
+ 
+ #include <tinyxml2.h>
+ #include <std_msgs/msg/string.hpp>

--- a/patch/ros-jazzy-mujoco-vendor.patch
+++ b/patch/ros-jazzy-mujoco-vendor.patch
@@ -1,0 +1,31 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index afa064a..81afd5d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,12 +20,19 @@ ament_vendor(mujoco_vendor
+     "-DCMAKE_C_FLAGS=-flto=auto"
+     GLOBAL_HOOK
+ )
+-ExternalProject_Get_Property(mujoco_vendor SOURCE_DIR)
+ 
+-install(DIRECTORY ${SOURCE_DIR}/simulate/
+-  DESTINATION opt/${PROJECT_NAME}/simulate
+-)
++# If the target is not defined,ament_vendor did not vendored the project with ExternalProject
++if(TARGET mujoco_vendor)
++  ExternalProject_Get_Property(mujoco_vendor SOURCE_DIR)
+ 
+-ament_package(
+-  CONFIG_EXTRAS_POST "mujoco_vendor-extra.cmake.in"
+-)
++  install(DIRECTORY ${SOURCE_DIR}/simulate/
++    DESTINATION opt/${PROJECT_NAME}/simulate
++  )
++
++  ament_package(
++    CONFIG_EXTRAS_POST "mujoco_vendor-extra.cmake.in"
++  )
++else()
++  ament_export_dependencies(mujoco)
++  ament_package()
++endif()

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -122,10 +122,10 @@ pybind11_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
 pybind11_json_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
-mujoco_vendor:
-  additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR"
 sick_scan_xd:
   additional_cmake_args: "-DBUILD_DEBUG_TARGET:BOOL=OFF -DROS_VERSION=2"
+mujoco_vendor:
+  additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK"
 visp:
   generate_dummy_package_with_run_deps:
     dep_name: visp

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -602,8 +602,6 @@ mosquitto:
   robostack: [paho-mqtt]
 msgpack:
   robostack: [msgpack-python]
-mujoco:
-  robostack: [libmujoco]
 muparser:
   robostack: [muparser]
 netpbm:

--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -3831,6 +3831,18 @@ multisensor_calibration_interface:
   tag: release/jazzy/multisensor_calibration_interface/2.0.4-1
   url: https://github.com/ros2-gbp/multisensor_calibration-release.git
   version: 2.0.4
+mujoco_ros2_control:
+  tag: release/jazzy/mujoco_ros2_control/0.0.1-1
+  url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
+  version: 0.0.1
+mujoco_ros2_control_demos:
+  tag: release/jazzy/mujoco_ros2_control_demos/0.0.1-1
+  url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
+  version: 0.0.1
+mujoco_ros2_control_msgs:
+  tag: release/jazzy/mujoco_ros2_control_msgs/0.0.1-1
+  url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
+  version: 0.0.1
 mvsim:
   tag: release/jazzy/mvsim/1.0.0-1
   url: https://github.com/ros2-gbp/mvsim-release.git

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -169,6 +169,10 @@ packages_select_by_deps:
 
   - rqt_robot_monitor
 
+  # mujoco
+  - mujoco_vendor
+  - mujoco_ros2_control_msgs
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:
@@ -198,6 +202,10 @@ packages_select_by_deps:
       - plansys2_tools
       - popf
   
+      # Use readlink and access at runtime linux-specific file
+      - mujoco_ros2_control
+      - mujoco_ros2_control_demos
+
   # These packages are currently only build on Linux, but they currently only build on
   # Linux as trying to build them in the past on macos or Windows resulted in errors
   - if: linux


### PR DESCRIPTION
Fixes #156

Add `mujoco_vendor` to `pkg_additional_info.yaml` with `-DAMENT_VENDOR_POLICY=NEVER_VENDOR` so that it uses `libmujoco` 3.5.0 from conda-forge instead of downloading it via ExternalProject. Also adds a `mujoco` → `libmujoco` mapping in `robostack.yaml` so the system dependency is resolved to the conda-forge package.