### PR TITLE
Add the moveit-ros-control-interface for jazzy

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -65,6 +65,7 @@ packages_select_by_deps:
   - moveit-ros-trajectory-cache
   - moveit-servo
   - moveit-visual-tools
+  - moveit-ros-control-interface
 
   - ros2_control
   - ros2_controllers
@@ -201,7 +202,7 @@ packages_select_by_deps:
       - plansys2_tests
       - plansys2_tools
       - popf
-  
+
       # Use readlink and access at runtime linux-specific file
       - mujoco_ros2_control
       - mujoco_ros2_control_demos


### PR DESCRIPTION
Many of the other packages are already built across all deps, just adding this to get access to non-deprecated controller managers.

Tested locally on linux-aarch64, but I'm uncertain if there were previous failures for other platforms that kept this from being added alongside the other moveit packages. It might need to be in conditional blocks.