### PR TITLE
Add remaining realsense2 ros packages for jazzy

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -201,10 +201,14 @@ packages_select_by_deps:
       - plansys2_tests
       - plansys2_tools
       - popf
-  
+
       # Use readlink and access at runtime linux-specific file
       - mujoco_ros2_control
       - mujoco_ros2_control_demos
+
+      # IntelRealSense
+      - realsense2-camera
+      - realsense2-description
 
   # These packages are currently only build on Linux, but they currently only build on
   # Linux as trying to build them in the past on macos or Windows resulted in errors


### PR DESCRIPTION
The drivers packages are already present, this just adds the ros2 wrappers for them to the linux build.

Based on the humble drivers, it seems as though these packages are linux only.