### PR TITLE
Add build for ros-jazzy-rtest package #2

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -54,7 +54,7 @@ c_stdlib:
   - vs                         # [win]
 c_stdlib_version:              # [unix]
   - 2.17                       # [linux]
-  - 10.13                      # [osx and x86_64]
+  - 11.0                       # [osx and x86_64]
   - 11.0                       # [osx and arm64]
 cxx_compiler:
   - gxx                        # [linux]

--- a/patch/ros-jazzy-rtest.patch
+++ b/patch/ros-jazzy-rtest.patch
@@ -1,0 +1,12 @@
+diff --git a/rtest/CMakeLists.txt b/rtest/CMakeLists.txt
+index 5d3673c..c699084 100644
+--- a/rtest/CMakeLists.txt
++++ b/rtest/CMakeLists.txt
+@@ -89,6 +89,7 @@ target_link_libraries(rtest_common PUBLIC
+   rcl_action::rcl_action
+   rclcpp::rclcpp
+   rclcpp_action::rclcpp_action
++  GTest::gmock
+ )
+ 
+ ament_export_dependencies(

--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -7479,3 +7479,7 @@ zstd_vendor:
   tag: release/jazzy/zstd_vendor/0.26.9-1
   url: https://github.com/ros2-gbp/rosbag2-release.git
   version: 0.26.9
+rtest:
+  tag: release/jazzy/rtest/0.2.1-1
+  url: https://github.com/ros2-gbp/rtest-release.git
+  version: 0.2.1

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -176,6 +176,8 @@ packages_select_by_deps:
   - mujoco_vendor
   - mujoco_ros2_control_msgs
 
+  - rtest
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:


### PR DESCRIPTION
This PR builds on the work started in #186.

I reproduced the issue locally on macOS arm64. The failure occurs at link time while building `rtest_common`, with unresolved `testing::...` / `testing::internal::...` symbols coming from Google Mock.

This matches the earlier upstream Linux report in Beam-and-Spyrosoft/rtest#91, where `librtest_common.so` also exposed unresolved GMock symbols. In that report, the issue disappeared once an `rtest` function was added, which suggests that the problem can be masked depending on how the final test target is linked.

From the current upstream CMake configuration, `rtest` does:

`find_package(GTest CONFIG REQUIRED COMPONENTS GTest GMock)`

However, `rtest_common` itself links only against:
- `rcl_action::rcl_action`
- `rclcpp::rclcpp`
- `rclcpp_action::rclcpp_action`

At the same time, `test_tools_add_doubles(...)` links `GTest::gmock` into the generated `*_test_doubles` targets. In practice, this means the GMock dependency is effectively restored in the helper path instead of being owned directly by `rtest_common`.

This likely explains why the issue remained partially hidden on Linux. The documented usage pattern builds tests from sources with `ament_add_gmock(...)`, and the test doubles helper also adds `GTest::gmock`, so the final test executable often ends up pulling GMock in anyway. On macOS and Windows, building `rtest_common` as a package artifact exposes the missing linkage immediately.

For RoboStack, this PR adds a patch on top of upstream so that the package can be built successfully across platforms. Longer term, the proper upstream fix would be to make `rtest_common` directly own the GMock dependency, while keeping `test_tools_add_doubles(...)` as a convenience layer rather than the place that compensates for missing linkage.

Related upstream references:
- Beam-and-Spyrosoft/rtest#91
- Beam-and-Spyrosoft/rtest#93
- Beam-and-Spyrosoft/rtest#102
- Beam-and-Spyrosoft/rtest#113