### PR TITLE
Add graph-monitor packages:  mw_stats_shim, rosgraph_monitor_msgs and rosgraph_monitor

### DIFF
--- a/patch/ros-jazzy-rmw-stats-shim.patch
+++ b/patch/ros-jazzy-rmw-stats-shim.patch
@@ -1,19 +1,37 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2d6e10f..7360c4e 100644
+index 2d6e10f..66ada90 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -19,9 +19,11 @@ if(NOT CMAKE_CXX_STANDARD)
+@@ -19,9 +19,15 @@ if(NOT CMAKE_CXX_STANDARD)
    set(CMAKE_CXX_STANDARD 17)
  endif()
  
--if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
--  add_compile_options(-Wall -Wextra -Wpedantic)
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   add_compile_options(-Wall -Wextra -Wpedantic)
 -  add_link_options("-Wl,--no-undefined")
+ endif()
++
 +include(CheckLinkerFlag)
 +check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)
 +
 +if(HAVE_LINKER_NO_UNDEFINED)
 +  add_link_options("LINKER:--no-undefined")
- endif()
++endif()
  
  find_package(ament_cmake REQUIRED)
+@@ -32,6 +38,8 @@ find_package(rosgraph_monitor_msgs REQUIRED)
+ find_package(rosidl_runtime_cpp REQUIRED)
+ find_package(rosidl_typesupport_cpp REQUIRED)
+ 
++find_package(Threads REQUIRED)
++
+ add_library(${PROJECT_NAME} SHARED
+   src/shim.cpp
+   src/stat_collector.cpp
+@@ -45,6 +53,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
+   rmw::rmw
+   rosidl_runtime_cpp::rosidl_runtime_cpp
+   rosidl_typesupport_cpp::rosidl_typesupport_cpp
++  Threads::Threads
+   ${rosgraph_monitor_msgs_TARGETS}
+ )

--- a/patch/ros-jazzy-rmw-stats-shim.patch
+++ b/patch/ros-jazzy-rmw-stats-shim.patch
@@ -1,0 +1,19 @@
+--- /tmp/graph_monitor-release/CMakeLists.txt	2026-04-13 22:15:15
++++ /tmp/CMakeLists.rmw_stats_shim.modified.txt	2026-04-13 22:15:07
+@@ -21,9 +21,15 @@
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   add_compile_options(-Wall -Wextra -Wpedantic)
+-  add_link_options("-Wl,--no-undefined")
+ endif()
+ 
++include(CheckLinkerFlag)
++check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)
++
++if(HAVE_LINKER_NO_UNDEFINED)
++  add_link_options("LINKER:--no-undefined")
++endif()
++
+ find_package(ament_cmake REQUIRED)
+ 
+ find_package(rcpputils REQUIRED)

--- a/patch/ros-jazzy-rmw-stats-shim.patch
+++ b/patch/ros-jazzy-rmw-stats-shim.patch
@@ -1,19 +1,19 @@
---- /tmp/graph_monitor-release/CMakeLists.txt	2026-04-13 22:15:15
-+++ /tmp/CMakeLists.rmw_stats_shim.modified.txt	2026-04-13 22:15:07
-@@ -21,9 +21,15 @@
- 
- if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-   add_compile_options(-Wall -Wextra -Wpedantic)
--  add_link_options("-Wl,--no-undefined")
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d6e10f..7360c4e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,9 +19,11 @@ if(NOT CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 17)
  endif()
  
+-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-  add_compile_options(-Wall -Wextra -Wpedantic)
+-  add_link_options("-Wl,--no-undefined")
 +include(CheckLinkerFlag)
 +check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)
 +
 +if(HAVE_LINKER_NO_UNDEFINED)
 +  add_link_options("LINKER:--no-undefined")
-+endif()
-+
- find_package(ament_cmake REQUIRED)
+ endif()
  
- find_package(rcpputils REQUIRED)
+ find_package(ament_cmake REQUIRED)

--- a/patch/ros-jazzy-rosgraph-monitor-msgs.patch
+++ b/patch/ros-jazzy-rosgraph-monitor-msgs.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b5069b0..ccb6fbb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,6 +23,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   add_compile_options(-Wall -Wextra -Wpedantic)
+ endif()
+ 
++include(CheckLinkerFlag)
++check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)
++
++if(HAVE_LINKER_NO_UNDEFINED)
++  add_link_options("LINKER:--no-undefined")
++endif()
++
+ find_package(ament_cmake REQUIRED)
+ find_package(builtin_interfaces REQUIRED)
+ find_package(rosidl_default_generators REQUIRED)

--- a/patch/ros-jazzy-rosgraph-monitor.patch
+++ b/patch/ros-jazzy-rosgraph-monitor.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 39e863d..df1df78 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,13 @@ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   add_compile_options(-Wall -Wextra -Wpedantic -Werror=switch)
+-  add_link_options("-Wl,--no-undefined")
++endif()
++
++include(CheckLinkerFlag)
++check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)
++
++if(HAVE_LINKER_NO_UNDEFINED)
++  add_link_options("LINKER:--no-undefined")
+ endif()
+ 
+ find_package(ament_cmake REQUIRED)

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -178,11 +178,6 @@ packages_select_by_deps:
 
   - rtest
 
-  # graph-monitor related packages
-  - rmw_stats_shim
-  - rosgraph_monitor_msgs
-  - rosgraph_monitor
-
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:
@@ -300,6 +295,11 @@ packages_select_by_deps:
       - kinematics_interface
       - kinematics_interface_kdl
       - libg2o
+      
+      # graph-monitor related packages
+      - rmw_stats_shim
+      - rosgraph_monitor_msgs
+      - rosgraph_monitor
 
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -178,6 +178,11 @@ packages_select_by_deps:
 
   - rtest
 
+  # graph-monitor related packages
+  - rmw_stats_shim
+  - rosgraph_monitor_msgs
+  - rosgraph_monitor
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:


### PR DESCRIPTION
# Add graph_monitor packages to RoboStack Jazzy

## Goal

Add the following ROS 2 Jazzy packages to the RoboStack distribution:

- `rmw_stats_shim`
- `rosgraph_monitor`
- `rosgraph_monitor_msgs`

## Description

This PR integrates the `graph_monitor` stack into RoboStack Jazzy.

These packages are already released via `ros2-gbp` for Jazzy, but are not currently available in RoboStack. 

The stack provides:

- **`rmw_stats_shim`** – an RMW wrapper used to collect topic statistics  
- **`rosgraph_monitor`** – ROS graph monitoring utilities  
- **`rosgraph_monitor_msgs`** – message definitions for monitoring  

## macOS Build Fix

During local testing on macOS (`osx-arm64`), the build of `rmw_stats_shim` failed at the linking stage with:
`ld: unknown option: --no-undefined`.  The root cause is an unconditional use of the GNU-style linker flag: `-Wl,--no-undefined`. This flag is not supported by the Apple linker.


This flag is not supported by the Apple linker.

### Solution

This PR includes a patch that replaces the unconditional linker flag with a portable check using CMake:

```cmake
include(CheckLinkerFlag)
check_linker_flag(CXX "LINKER:--no-undefined" HAVE_LINKER_NO_UNDEFINED)

if(HAVE_LINKER_NO_UNDEFINED)
  add_link_options("LINKER:--no-undefined")
endif()
```

This ensures:
- the flag is used where supported (Linux),
- the build succeeds on macOS,
- no platform-specific hardcoding is require

### License
The graph_monitor packages are licensed under the Apache-2.0 license.
This PR does not modify upstream functionality beyond: RoboStack packaging integration and minimal build-system portability fix.
