### PR TITLE
fix: ignore chrony system service

### DIFF
--- a/packages-ignore.yaml
+++ b/packages-ignore.yaml
@@ -2,7 +2,10 @@
 rti-connext-dds-5.3.1:
   conda-forge: []
 
-# System service/runtime package used by TurtleBot 4 setup.
+# System service/runtime packages used by TurtleBot 4 setup.
+chrony:
+  robostack: []
+
 network-manager:
   robostack: []
 

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -43,11 +43,6 @@ ca-certificates:
   robostack: [ca-certificates]
 cargo:
   robostack: [rust]
-chrony:
-  robostack:
-    linux: [chrony]
-    osx: [chrony]
-    win64: []
 clang-format:
   robostack: [clang-format]
 clang-tidy:


### PR DESCRIPTION
Port of https://github.com/RoboStack/ros-humble/pull/406