### PR TITLE
Bump fmt logger to 1.1.0

### DIFF
--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -5400,9 +5400,9 @@ ros2_controllers_test_nodes:
   url: https://github.com/ros2-gbp/ros2_controllers-release.git
   version: 4.37.0
 ros2_fmt_logger:
-  tag: release/jazzy/ros2_fmt_logger/1.0.2-1
+  tag: release/jazzy/ros2_fmt_logger/1.1.0-1
   url: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
-  version: 1.0.2
+  version: 1.1.0
 ros2_socketcan:
   tag: release/jazzy/ros2_socketcan/1.3.0-1
   url: https://github.com/ros2-gbp/ros2_socketcan-release.git


### PR DESCRIPTION
Does this always need to be a manual action or is there some kind of syncing?