### PR TITLE
fix link error on build of rosidl_generator_py on macOS

### DIFF
--- a/patch/ros-jazzy-rosidl-generator-py.osx.patch
+++ b/patch/ros-jazzy-rosidl-generator-py.osx.patch
@@ -23,11 +23,16 @@ index cfc424a..cddd23d 100644
  target_include_directories(${_target_name_lib}
    PRIVATE
    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
-@@ -162,8 +158,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+@@ -162,8 +158,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
    set(_extension_compile_flags -Wall -Wextra)
  endif()
  
-+target_link_libraries(${_target_name_lib} PRIVATE Python3::NumPy Python3::Python)
++if(APPLE)
++  target_link_libraries(${_target_name_lib} PRIVATE Python3::NumPy Python3::Module)
++  target_include_directories(${_target_name_lib} PRIVATE ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
++else()
++  target_link_libraries(${_target_name_lib} PUBLIC Python3::NumPy Python3::Python)
++endif()
 +
  rosidl_get_typesupport_target(c_typesupport_target "${rosidl_generate_interfaces_TARGET}" "rosidl_typesupport_c")
 -target_link_libraries(${_target_name_lib} PRIVATE ${c_typesupport_target})

--- a/patch/ros-jazzy-rosidl-generator-py.osx.patch
+++ b/patch/ros-jazzy-rosidl-generator-py.osx.patch
@@ -23,16 +23,11 @@ index cfc424a..cddd23d 100644
  target_include_directories(${_target_name_lib}
    PRIVATE
    ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_c
-@@ -162,8 +158,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+@@ -162,8 +158,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
    set(_extension_compile_flags -Wall -Wextra)
  endif()
  
-+if(APPLE)
-+  set_target_properties(${_target_name_lib} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-+  target_include_directories(${_target_name_lib} PUBLIC ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
-+else()
-+  target_link_libraries(${_target_name_lib} PUBLIC Python3::NumPy Python3::Python)
-+endif()
++target_link_libraries(${_target_name_lib} PRIVATE Python3::NumPy Python3::Python)
 +
  rosidl_get_typesupport_target(c_typesupport_target "${rosidl_generate_interfaces_TARGET}" "rosidl_typesupport_c")
 -target_link_libraries(${_target_name_lib} PRIVATE ${c_typesupport_target})


### PR DESCRIPTION
# Fix linking error on macOS build

## Overview

While working on my master thesis with RoboStack Jazzy I had to rebuild a number of packages on an ARM64 Mac, where `builtin_interfaces` failed with an undefined-symbol linker error (see below).

By investigating the build output I traced the error back to the `rosidl_generator_py` package and its macOS patch. I then used AI to understand the root cause and find the correct fix.

**Root cause (AI-assisted explanation):** The macOS patch relied on `-undefined dynamic_lookup` to leave the Python symbols of the generated `*__rosidl_generator_py` **shared library** unresolved at link time. With the current conda-forge clang/linker toolchain, `-Wl,-undefined,error` is injected into `LDFLAGS` and overrides `-undefined dynamic_lookup`, so the linker now fails on those unresolved symbols.

**Fix:** Link the Python libraries into the shared library explicitly. Using `PRIVATE` is important: it resolves the symbols inside the library without adding `Python3::NumPy` / `Python3::Python` to the exported link interface — otherwise downstream packages that don't call `find_package(Python3)` would fail with `Python3::NumPy ... target was not found`.

## How to reproduce the error

1. Clone the `ros-jazzy` repo on a macOS machine.
2. Force a rebuild of `rosidl_generator_py`, `rosidl_core_generators` and `builtin_interfaces`, e.g. by bumping their build numbers in `pkg_additional_info.yaml`:

```yaml
rosidl_generator_py:
  build_number: 17

rosidl_core_generators:
  build_number: 17

builtin_interfaces:
  build_number: 17
```

`rosidl_core_generators` is required so that `builtin_interfaces` picks up the freshly built `rosidl_generator_py` instead of the one from the remote channel.

3. Run `pixi run build`. The error appears while building `builtin_interfaces`.

With the changed patch in this PR it builds successfully on ARM64 macOS.

I could not test it on x86_64 macOS.

## Error message while building `builtin_interfaces`:

```
 ...
 │ │ [40/48] Building C object CMakeFiles/builtin_interfaces__rosidl_generator_py.dir/rosidl_ge
 │ │ nerator_py/builtin_interfaces/msg/_duration_s.c.o
 │ │ [41/48] Building C object CMakeFiles/builtin_interfaces__rosidl_generator_py.dir/rosidl_ge
 │ │ nerator_py/builtin_interfaces/msg/_time_s.c.o
 │ │ [42/48] Linking C shared library libbuiltin_interfaces__rosidl_generator_py.dylib
 │ │ FAILED: [code=1] libbuiltin_interfaces__rosidl_generator_py.dylib 
 │ │ : && $BUILD_PREFIX/bin/arm64-apple-darwin20.0.0-clang -ftree-vectorize -fPIC -fstack-prote
 │ │ ctor-strong -O2 -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/
 │ │ conda/ros-jazzy-builtin-interfaces-2.0.3 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-p
 │ │ refix -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.s
 │ │ dk -mmacosx-version-min=10.15 -dynamiclib -Wl,-headerpad_max_install_names -Wl,-headerpad_
 │ │ max_install_names -Wl,-dead_strip_dylibs -Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -Wl,-undefin
 │ │ ed,error  -undefined dynamic_lookup -o libbuiltin_interfaces__rosidl_generator_py.dylib -i
 │ │ nstall_name @rpath/libbuiltin_interfaces__rosidl_generator_py.dylib CMakeFiles/builtin_int
 │ │ erfaces__rosidl_generator_py.dir/rosidl_generator_py/builtin_interfaces/msg/_duration_s.c.
 │ │ o CMakeFiles/builtin_interfaces__rosidl_generator_py.dir/rosidl_generator_py/builtin_inter
 │ │ faces/msg/_time_s.c.o  -Wl,-rpath,$SRC_DIR/build  libbuiltin_interfaces__rosidl_typesuppor
 │ │ t_c.dylib  libbuiltin_interfaces__rosidl_generator_c.dylib  $PREFIX/lib/librosidl_runtime_
 │ │ c.dylib  $PREFIX/lib/librcutils.dylib && :
 │ │ Undefined symbols for architecture arm64:
 │ │   "_PyImport_ImportModule", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "_PyLong_AsLong", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_from_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_from_py in _time_s.c.o
 │ │   "_PyLong_AsUnsignedLong", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_from_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_from_py in _time_s.c.o
 │ │   "_PyLong_FromLong", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "_PyLong_FromUnsignedLong", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "_PyObject_CallObject", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "_PyObject_GetAttrString", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_from_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_from_py in _time_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "_PyObject_SetAttrString", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │   "__Py_Dealloc", referenced from:
 │ │       _builtin_interfaces__msg__duration__convert_from_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__duration__convert_to_py in _duration_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_from_py in _time_s.c.o
 │ │       _builtin_interfaces__msg__time__convert_to_py in _time_s.c.o
 │ │ ld: symbol(s) not found for architecture arm64
 │ │ arm64-apple-darwin20.0: error: linker command failed with exit code 1 (use -v to see invoc
 │ │ ation)
 │ │ [43/48] cd $SRC_DIR/build && $BUILD_PREFIX/bin/cmake -E copy_directory $SRC_DIR/build/rosi
 │ │ dl_generator_py/builtin_interfaces $SRC_DIR/build/ament_cmake_python/builtin_interfaces/bu
 │ │ iltin_interfaces
 │ │ ninja: build stopped: subcommand failed.
 │ │ × error Script failed with status 1
 │ │ × error 
 │ │ × error Script execution failed.
 │ │ × error 
 │ │ × error   Work directory: /Users/user/EigeneDokumente/Uni/code
 │ │ × error /ros-jazzy/output/bld/rattler-build_ros-jazzy-builtin-interfaces_17811
 │ │ × error 88656/work
 │ │ × error   Prefix: /Users/user/EigeneDokumente/Uni/code/r
 │ │ × error os-jazzy/output/bld/rattler-build_ros-jazzy-builtin-interfaces_1781188656/ho
 │ │ × error st_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh
 │ │ × error old_placehold_pl
 │ │ × error   Build prefix: /Users/user/EigeneDokumente/Uni/code
 │ │ × error /ros-jazzy/output/bld/rattler-build_ros-jazzy-builtin-interfaces_1781188
 │ │ × error 656/build_env
 │ │ × error 
 │ │ × error To run the script manually, use the following command:
 │ │ × error 
 │ │ × error   cd "/Users/user/EigeneDokumente/Uni/code/ros-j
 │ │ × error azzy/output/bld/rattler-build_ros-jazzy-builtin-interfaces_1781188656/work" 
 │ │ × error && ./conda_build.sh
 │ │ × error 
 │ │ × error To run commands interactively in the build environment:
 │ │ × error 
 │ │ × error   cd "/Users/user/EigeneDokumente/Uni/code/ros-j
 │ │ × error azzy/output/bld/rattler-build_ros-jazzy-builtin-interfaces_1781188656/work" 
 │ │ × error && source build_env.sh
 │ │
 │ ╰─────────────────── (took 42 seconds)
 │
 ╰─────────────────── (took 52 seconds)
Error:   × Script failed to execute
```