### PR TITLE
Fix pixi crash on liblttng-ust-dev

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -352,7 +352,10 @@ libhdf5-dev:
 libi2c-dev:
   robostack: [libi2c]
 liblttng-ust-dev:
-  robostack: ["${{ \"lttng-ust\" if linux }}"]
+  robostack:
+    linux: [lttng-ust]
+    osx: []
+    win64: []
 libjpeg:
   robostack: [libjpeg-turbo]
 libjsoncpp:


### PR DESCRIPTION
To reproduce:

```
git clone https://github.com/robosoft-ai/SMACC2
cd SMACC2/
pixi-ros init --distro jazzy --platform linux-64
```

<img width="600" height="228" alt="image" src="https://github.com/user-attachments/assets/d2ff6201-e0c7-48f3-92cd-274e823fd329" />
