### PR TITLE
Reintroduce library_path.sh patches from humble to fix LD_LIBRARY_PATH pollution

### DIFF
--- a/patch/ros-jazzy-ament-cmake-core.patch
+++ b/patch/ros-jazzy-ament-cmake-core.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/package_templates/templates_2_cmake.py b/cmake/package_templates/templates_2_cmake.py
+index b7c0faf..328cc38 100644
+--- a/cmake/package_templates/templates_2_cmake.py
++++ b/cmake/package_templates/templates_2_cmake.py
+@@ -68,12 +68,7 @@ def generate_cmake_code():
+     """
+     variables = []
+ 
+-    if not IS_WINDOWS:
+-        variables.append((
+-            'ENVIRONMENT_HOOK_LIBRARY_PATH',
+-            '"%s"' % get_environment_hook_template_path('library_path.sh')))
+-    else:
+-        variables.append(('ENVIRONMENT_HOOK_LIBRARY_PATH', ''))
++    variables.append(('ENVIRONMENT_HOOK_LIBRARY_PATH', ''))
+ 
+     ext = '.bat.in' if IS_WINDOWS else '.sh.in'
+     variables.append((

--- a/patch/ros-jazzy-ament-package.patch
+++ b/patch/ros-jazzy-ament-package.patch
@@ -1,0 +1,22 @@
+diff --git a/ament_package/template/environment_hook/library_path.sh b/ament_package/template/environment_hook/library_path.sh
+deleted file mode 100644
+index 292e518..0000000
+--- a/ament_package/template/environment_hook/library_path.sh
++++ /dev/null
+@@ -1,16 +0,0 @@
+-# copied from ament_package/template/environment_hook/library_path.sh
+-
+-# detect if running on Darwin platform
+-_UNAME=`uname -s`
+-_IS_DARWIN=0
+-if [ "$_UNAME" = "Darwin" ]; then
+-  _IS_DARWIN=1
+-fi
+-unset _UNAME
+-
+-if [ $_IS_DARWIN -eq 0 ]; then
+-  ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-else
+-  ament_prepend_unique_value DYLD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-fi
+-unset _IS_DARWIN


### PR DESCRIPTION
Closes #228 

As title (reasoning are addressed in the issue). This restores the humble patches that were deleted in this [commit](https://github.com/RoboStack/ros-jazzy/commit/b30b254e258cba267231aff59d469daf938d7681). I couldn't find a reason why these patches were deleted rather than migrated to Jazzy unfortunately

There are three patches in humble that touches `library_path.sh`:
- `ament-package` - The patch that deletes `library_path.sh` is taken from [humble](https://github.com/RoboStack/ros-humble/blob/main/patch/ros-humble-ament-package.patch). The second hunk that modifies `templates.py` to use importlib for file operations is already modernized in [Jazzy](https://github.com/ament/ament_package/blob/jazzy/ament_package/templates.py) so I omitted it. 
- `ament-cmake-core` - The patch is taken verbatim from [humble](https://github.com/RoboStack/ros-humble/blob/main/patch/ros-humble-ament-cmake-core.patch)
- `ros-workspace` - The patch with equivalent content already exists for jazzy [here](https://github.com/Ryan4253/ros-jazzy/blob/main/patch/ros-jazzy-ros-workspace.patch)

Verification:
- Both patches pass `git apply --check`
- I simulated the post rebuild state by removing all `library_path.{sh, dsv}` and their `local_setup` references. `$CONDA_PREFIX/lib` no longer appears in `LD_LIBRARY_PATH`, `ros2` / `rclpy` still load, and system binaries like git now runs

Note: A rebuild of all packages that uses `library_path.sh` will likely be needed after this merge