### PR TITLE
fix sqlite3_vendor missing dep in linux build

### DIFF
--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -280,3 +280,6 @@ cloudini_ros:
 swri_console:
   add_host: ["libboost-devel"]
   add_run: ["libboost"]
+warehouse_ros_sqlite:
+  add_host: ["ros-jazzy-sqlite3-vendor"]
+  add_run: ["ros-jazzy-sqlite3-vendor"]


### PR DESCRIPTION
linux.yml failed on warehouse_ros_sqlite: https://github.com/RoboStack/ros-jazzy/actions/runs/28093617150 due to missing sqlite3-vendor dependency.

This PR shall unblock it

