### PR TITLE
Remove moveit_task_constructor_* and rviz_marker_tools additional recipes (now via ros2-gbp)

### DIFF
--- a/rosdistro_additional_recipes.yaml
+++ b/rosdistro_additional_recipes.yaml
@@ -10,32 +10,6 @@ livox_ros_driver2:
   # other modification, regular patch files should be used.
   package_xml_name: package_ROS2.xml
 
-# TODO: remove moveit_task_constructor and its sub packages when they are available from ros2-gbp
-moveit_task_constructor_capabilities:
-  tag: release/jazzy/moveit_task_constructor_capabilities/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-moveit_task_constructor_core:
-  tag: release/jazzy/moveit_task_constructor_core/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-moveit_task_constructor_demo:
-  tag: release/jazzy/moveit_task_constructor_demo/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-moveit_task_constructor_msgs:
-  tag: release/jazzy/moveit_task_constructor_msgs/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-moveit_task_constructor_visualization:
-  tag: release/jazzy/moveit_task_constructor_visualization/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-rviz_marker_tools:
-  tag: release/jazzy/rviz_marker_tools/0.1.3-1
-  url: https://github.com/wep21/moveit_task_constructor-release.git
-  version: 0.1.3
-
 # TODO: remove ros2_kortex and its sub packages when they are available for jazzy
 kinova_gen3_6dof_robotiq_2f_85_moveit_config:
   tag: release/humble/kinova_gen3_6dof_robotiq_2f_85_moveit_config/0.2.3-1


### PR DESCRIPTION
This PR removes the manual mtc* and rviz_marker_tools overrides from rosdistro_additional_recipes.yaml, which pointed to an unofficial third-party release fork. This repo has two conflicting sources for the same packages. Because additional_recipes.yaml takes precedence over snapshot.yaml, the build was silently stuck on the old, unofficial, stale repo instead of using the newer official release.

This PR simply deletes the now-redundant override so the build falls through to the official source.