### PR TITLE
Missing library with turtlebot4 packages

### DIFF
--- a/patch/ros-jazzy-turtlebot4-gz-toolbox.patch
+++ b/patch/ros-jazzy-turtlebot4-gz-toolbox.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d03643..15dcb6c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@ include_directories(
+   include
+ )
+ 
+-add_library(${PROJECT_NAME}_lib
++add_library(${PROJECT_NAME}_lib STATIC
+   "src/hmi_main.cpp"
+   "src/hmi_node.cpp"
+ )

--- a/patch/ros-jazzy-turtlebot4-node.patch
+++ b/patch/ros-jazzy-turtlebot4-node.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec7088e..2c8715b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,7 +32,7 @@ include_directories(
+   include
+ )
+ 
+-add_library(${PROJECT_NAME}_lib
++add_library(${PROJECT_NAME}_lib STATIC
+   "src/main.cpp"
+   "src/turtlebot4.cpp"
+   "src/display.cpp"


### PR DESCRIPTION
When pulling the newest turtle4 packages and running them I get the following error on Ubuntu (wsl) complaining about the missing libraries

wsl2 ubuntu 24.04
```bash
Turtlebot4_node-30] /home/xxx/xxx/xxx/tb4_pixi/.pixi/envs/default/lib/turtlebot4_node/turtlebot4_node: error while loading shared libraries: libturtlebot4_node_lib.so: cannot open shared object file: No such file or directory
[turtlebot4_gz_hmi_node-31] /home/xxx/xxx/xxx/tb4_pixi/.pixi/envs/default/lib/turtlebot4_gz_toolbox/turtlebot4_gz_hmi_node: error while loading shared libraries: libturtlebot4_gz_toolbox_lib.so: cannot open shared object file: No such file or directory
```
Win11 (code 3221225781 means missing dll)
```pws
[ERROR] [turtlebot4_node.EXE-30]: process has died [pid 31580, exit code 3221225781, cmd 'C:\Users\xxx\xxx\xxx\tb4_pixi\.pixi\envs\default\Library\lib\turtlebot4_node\turtlebot4_node.EXE --ros-args -r __node:=turtlebot4_node -r __ns:=/ --params-file C:\Users\xxx\xxx\xxx\tb4_pixi\.pixi\envs\default\Library\share\turtlebot4_gz_bringup\config\turtlebot4_node.yaml --params-file C:\Users\xxx\AppData\Local\Temp\launch_params_z8xxutbi'].
[INFO] [turtlebot4_gz_hmi_node.EXE-31]: process started with pid [8072]
[ERROR] [turtlebot4_gz_hmi_node.EXE-31]: process has died [pid 8072, exit code 3221225781, cmd 'C:\Users\xxx\xxx\xxx\tb4_pixi\.pixi\envs\default\Library\lib\turtlebot4_gz_toolbox\turtlebot4_gz_hmi_node.EXE --ros-args -r __node:=turtlebot4_gz_hmi_node -r __ns:=/'].
```
I haven't tried macOS but it is very likely having the same problem.

Will hopefully closes #241 