### PR TITLE
Add PyTrees packages

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -232,6 +232,15 @@ packages_select_by_deps:
 
   - urdf_tutorial
 
+  # py_trees stack
+  - py_trees
+  - py_trees_ros_interfaces
+  - py_trees_ros
+  - py_trees_js
+  - py_trees_ros_viewer
+  - py_trees_ros_tutorial
+
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:


### PR DESCRIPTION
Question: I recently put up an official conda package for `py_trees` : https://anaconda.org/channels/conda-forge/packages/py-trees/overview so not sure how to make sure it comes from there and not from the ROS one?