### PR TITLE
Bound turtlebot4 ros2 run smoke tests

### DIFF
--- a/tests/ros-jazzy-turtlebot4-gz-toolbox.yaml
+++ b/tests/ros-jazzy-turtlebot4-gz-toolbox.yaml
@@ -1,7 +1,7 @@
 tests:
   # Regression test for https://github.com/RoboStack/ros-jazzy/pull/246
   - script:
-    - python -c "import subprocess,sys,time; q=subprocess.Popen(['ros2','run','turtlebot4_gz_toolbox','turtlebot4_gz_hmi_node']); time.sleep(3); rc=q.poll(); q.terminate() if rc is None else None; q.wait(); sys.exit(0 if rc is None else rc)"
+    - python -c "import os,signal,subprocess,sys,time; kw={'creationflags':subprocess.CREATE_NEW_PROCESS_GROUP} if os.name=='nt' else {'start_new_session':True}; p=subprocess.Popen(['ros2','run','turtlebot4_gz_toolbox','turtlebot4_gz_hmi_node'],**kw); time.sleep(3); rc=p.poll(); (subprocess.run(['taskkill','/F','/T','/PID',str(p.pid)]) if os.name=='nt' else os.killpg(p.pid,signal.SIGKILL)) if rc is None else None; sys.exit(0 if rc is None else rc)"
     requirements:
       run:
         - ros-jazzy-ros2run

--- a/tests/ros-jazzy-turtlebot4-node.yaml
+++ b/tests/ros-jazzy-turtlebot4-node.yaml
@@ -1,7 +1,7 @@
 tests:
   # Regression test for https://github.com/RoboStack/ros-jazzy/pull/246
   - script:
-    - python -c "import subprocess,sys,time; q=subprocess.Popen(['ros2','run','turtlebot4_node','turtlebot4_node']); time.sleep(3); rc=q.poll(); q.terminate() if rc is None else None; q.wait(); sys.exit(0 if rc is None else rc)"
+    - python -c "import os,signal,subprocess,sys,time; kw={'creationflags':subprocess.CREATE_NEW_PROCESS_GROUP} if os.name=='nt' else {'start_new_session':True}; p=subprocess.Popen(['ros2','run','turtlebot4_node','turtlebot4_node'],**kw); time.sleep(3); rc=p.poll(); (subprocess.run(['taskkill','/F','/T','/PID',str(p.pid)]) if os.name=='nt' else os.killpg(p.pid,signal.SIGKILL)) if rc is None else None; sys.exit(0 if rc is None else rc)"
     requirements:
       run:
         - ros-jazzy-ros2run


### PR DESCRIPTION
Follow-up to #254.

The turtlebot4 smoke tests start long-running ROS 2 nodes with `ros2 run`, so a successful start needs to be treated as pass after a short window. The previous wrapper called `terminate()` on the `ros2 run` launcher and then waited, which can hang because `ros2 run` spawns the actual executable.

This runs `ros2 run` in its own process group/session and force-cleans the process tree after 3 seconds. Early exits still propagate the real return code, so shared-library loader failures continue to fail the test.

Verified locally:
- `pixi run generate-recipes`
- `pixi run build-one ros-jazzy-turtlebot4-node`
- `pixi run build-one ros-jazzy-turtlebot4-gz-toolbox`