### PR TITLE
Add negotiated and topic_based_ros2_control

### DIFF
--- a/rosdistro_additional_recipes.yaml
+++ b/rosdistro_additional_recipes.yaml
@@ -10,6 +10,24 @@ livox_ros_driver2:
   # other modification, regular patch files should be used.
   package_xml_name: package_ROS2.xml
 
+# Generic dependencies used by Isaac ROS that do not have Jazzy rosdistro releases.
+# Keep the revisions aligned with the versions validated by isaac-forge.
+negotiated_interfaces:
+  url: https://github.com/osrf/negotiated.git
+  rev: eac198b55dcd052af5988f0f174902913c5f20e7
+  version: 0.1.0
+  additional_folder: negotiated_interfaces
+negotiated:
+  url: https://github.com/osrf/negotiated.git
+  rev: eac198b55dcd052af5988f0f174902913c5f20e7
+  version: 0.1.0
+  additional_folder: negotiated
+
+topic_based_ros2_control:
+  url: https://github.com/PickNikRobotics/topic_based_ros2_control.git
+  rev: 6bd8d55e1c4ad3188770fe5c8b93b942bcede4a2
+  version: 0.3.0
+
 # TODO: remove moveit_task_constructor and its sub packages when they are available from ros2-gbp
 moveit_task_constructor_capabilities:
   tag: release/jazzy/moveit_task_constructor_capabilities/0.1.3-1

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -48,6 +48,10 @@ packages_select_by_deps:
   - ament_cmake_catch2
   - ament_cmake_mypy
 
+  # Generic dependencies used by Isaac ROS without Jazzy rosdistro releases.
+  - negotiated
+  - topic_based_ros2_control
+
   - desktop
   - ros_base
   - ros_environment


### PR DESCRIPTION
Add three generic Jazzy packages currently carried by isaac-forge:

- `negotiated_interfaces`
- `negotiated`
- `topic_based_ros2_control`

None has a Jazzy rosdistro release, so they are pinned as additional recipes to the revisions validated by isaac-forge. `negotiated` is a foundational NITROS dependency; `topic_based_ros2_control` is used by the manipulation robot descriptions.

Validated locally on linux-64 with generated RoboStack recipes; all three build and pass package tests.