### PR TITLE
Add ros2_medkit packages

### DIFF
--- a/patch/ros-jazzy-ros2-medkit-serialization.patch
+++ b/patch/ros-jazzy-ros2-medkit-serialization.patch
@@ -1,0 +1,13 @@
+diff --git a/src/vendored/dynmsg/message_reading_cpp.cpp b/src/vendored/dynmsg/message_reading_cpp.cpp
+index 16a3cd1..743008a 100644
+--- a/src/vendored/dynmsg/message_reading_cpp.cpp
++++ b/src/vendored/dynmsg/message_reading_cpp.cpp
+@@ -398,7 +398,7 @@ dynamic_array_to_yaml_impl_bool(
+   static_cast<void>(member_info);
+   for (size_t ii = 0; ii < v->size(); ++ii) {
+     DYNMSG_DEBUG(std::cout << (v->operator[](ii) ? "true" : "false") << ", ");
+-    array_node.push_back(v->operator[](ii));
++    array_node.push_back(static_cast<bool>(v->operator[](ii)));
+   }
+   DYNMSG_DEBUG(std::cout << std::endl);
+ }

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -509,6 +509,8 @@ libsndfile1-dev:
   robostack: [libsndfile]
 libspnav-dev:
   robostack: [libspnav, xorg-xorgproto]
+libcpp-httplib-dev:
+  robostack: [cpp-httplib]
 libsqlite3-dev:
   robostack: [sqlite 3.*]
 libssl-dev:

--- a/rosdistro_additional_recipes.yaml
+++ b/rosdistro_additional_recipes.yaml
@@ -171,3 +171,72 @@ lbr_fri_idl:
   url: https://github.com/lbr-stack/lbr_fri_idl.git
   rev: e422bff2b3d70ec47853145b35645980df623a60
   version: 1.5.0
+# ros2_medkit 0.6.0 (16 packages released to jazzy).
+# The jazzy snapshot pins 0.4.0, which fails to build against conda-forge's
+# cpp-httplib 0.51 (gateway used the removed get_file_value API; fixed upstream
+# in 0.6.0 via the MultipartFormData API). fault_detection, graph_watchdog and
+# opcua are not released to jazzy, so they are intentionally omitted.
+ros2_medkit_action_status_bridge:
+  tag: release/jazzy/ros2_medkit_action_status_bridge/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_beacon_common:
+  tag: release/jazzy/ros2_medkit_beacon_common/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_cmake:
+  tag: release/jazzy/ros2_medkit_cmake/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_diagnostic_bridge:
+  tag: release/jazzy/ros2_medkit_diagnostic_bridge/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_fault_manager:
+  tag: release/jazzy/ros2_medkit_fault_manager/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_fault_reporter:
+  tag: release/jazzy/ros2_medkit_fault_reporter/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_gateway:
+  tag: release/jazzy/ros2_medkit_gateway/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_graph_provider:
+  tag: release/jazzy/ros2_medkit_graph_provider/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_integration_tests:
+  tag: release/jazzy/ros2_medkit_integration_tests/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_linux_introspection:
+  tag: release/jazzy/ros2_medkit_linux_introspection/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_log_bridge:
+  tag: release/jazzy/ros2_medkit_log_bridge/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_msgs:
+  tag: release/jazzy/ros2_medkit_msgs/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_param_beacon:
+  tag: release/jazzy/ros2_medkit_param_beacon/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_serialization:
+  tag: release/jazzy/ros2_medkit_serialization/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_sovd_service_interface:
+  tag: release/jazzy/ros2_medkit_sovd_service_interface/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0
+ros2_medkit_topic_beacon:
+  tag: release/jazzy/ros2_medkit_topic_beacon/0.6.0-1
+  url: https://github.com/ros2-gbp/ros2_medkit-release.git
+  version: 0.6.0

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -250,27 +250,19 @@ packages_select_by_deps:
   - ros2_medkit_action_status_bridge
   - ros2_medkit_cmake
   - ros2_medkit_diagnostic_bridge
-  - ros2_medkit_fault_detection
   - ros2_medkit_fault_manager
   - ros2_medkit_fault_reporter
+  - ros2_medkit_integration_tests
   - ros2_medkit_log_bridge
   - ros2_medkit_msgs
   - ros2_medkit_serialization
-
-  # gateway + dependents need cpp-httplib, which conda-forge does not ship
-  # for ARM (osx-arm64 / linux-aarch64) — see conda-forge/cpp-httplib-feedstock
-  - if: not (aarch64 or arm64)
-    then:
-      - ros2_medkit_beacon_common
-      - ros2_medkit_gateway
-      - ros2_medkit_graph_provider
-      - ros2_medkit_graph_watchdog
-      - ros2_medkit_integration_tests
-      - ros2_medkit_linux_introspection
-      - ros2_medkit_opcua
-      - ros2_medkit_param_beacon
-      - ros2_medkit_sovd_service_interface
-      - ros2_medkit_topic_beacon
+  - ros2_medkit_beacon_common
+  - ros2_medkit_gateway
+  - ros2_medkit_graph_provider
+  - ros2_medkit_linux_introspection
+  - ros2_medkit_param_beacon
+  - ros2_medkit_sovd_service_interface
+  - ros2_medkit_topic_beacon
 
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -246,24 +246,6 @@ packages_select_by_deps:
   - py_trees_ros_viewer
   - py_trees_ros_tutorials
 
-  # ros2_medkit diagnostic stack (https://index.ros.org/r/ros2_medkit/)
-  - ros2_medkit_action_status_bridge
-  - ros2_medkit_cmake
-  - ros2_medkit_diagnostic_bridge
-  - ros2_medkit_fault_manager
-  - ros2_medkit_fault_reporter
-  - ros2_medkit_integration_tests
-  - ros2_medkit_log_bridge
-  - ros2_medkit_msgs
-  - ros2_medkit_serialization
-  - ros2_medkit_beacon_common
-  - ros2_medkit_gateway
-  - ros2_medkit_graph_provider
-  - ros2_medkit_linux_introspection
-  - ros2_medkit_param_beacon
-  - ros2_medkit_sovd_service_interface
-  - ros2_medkit_topic_beacon
-
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:
@@ -304,6 +286,24 @@ packages_select_by_deps:
 
       - septentrio_gnss_driver
 
+      # ros2_medkit diagnostic stack (https://index.ros.org/r/ros2_medkit/)
+      - ros2_medkit_action_status_bridge
+      - ros2_medkit_cmake
+      - ros2_medkit_diagnostic_bridge
+      - ros2_medkit_fault_manager
+      - ros2_medkit_fault_reporter
+      - ros2_medkit_integration_tests
+      - ros2_medkit_log_bridge
+      - ros2_medkit_msgs
+      - ros2_medkit_serialization
+      - ros2_medkit_beacon_common
+      - ros2_medkit_gateway
+      - ros2_medkit_graph_provider
+      - ros2_medkit_linux_introspection
+      - ros2_medkit_param_beacon
+      - ros2_medkit_sovd_service_interface
+      - ros2_medkit_topic_beacon
+      
   # These packages are currently only build on Linux, but they currently only build on
   # Linux as trying to build them in the past on macos or Windows resulted in errors
   - if: linux
@@ -395,7 +395,7 @@ packages_select_by_deps:
       - rmw_stats_shim
       - rosgraph_monitor_msgs
       - rosgraph_monitor
-
+      
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml
 rosdistro_additional_recipes: rosdistro_additional_recipes.yaml

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -246,6 +246,32 @@ packages_select_by_deps:
   - py_trees_ros_viewer
   - py_trees_ros_tutorials
 
+  # ros2_medkit diagnostic stack (https://index.ros.org/r/ros2_medkit/)
+  - ros2_medkit_action_status_bridge
+  - ros2_medkit_cmake
+  - ros2_medkit_diagnostic_bridge
+  - ros2_medkit_fault_detection
+  - ros2_medkit_fault_manager
+  - ros2_medkit_fault_reporter
+  - ros2_medkit_log_bridge
+  - ros2_medkit_msgs
+  - ros2_medkit_serialization
+  
+  # gateway + dependents: need cpp-httplib, missing on osx-arm64 in conda-forge
+  # (conda-forge/cpp-httplib-feedstock has no osx_arm64 build)
+  - if: not osx
+    then:
+      - ros2_medkit_beacon_common
+      - ros2_medkit_gateway
+      - ros2_medkit_graph_provider
+      - ros2_medkit_graph_watchdog
+      - ros2_medkit_integration_tests
+      - ros2_medkit_linux_introspection
+      - ros2_medkit_opcua
+      - ros2_medkit_param_beacon
+      - ros2_medkit_sovd_service_interface
+      - ros2_medkit_topic_beacon
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -256,10 +256,10 @@ packages_select_by_deps:
   - ros2_medkit_log_bridge
   - ros2_medkit_msgs
   - ros2_medkit_serialization
-  
-  # gateway + dependents: need cpp-httplib, missing on osx-arm64 in conda-forge
-  # (conda-forge/cpp-httplib-feedstock has no osx_arm64 build)
-  - if: not osx
+
+  # gateway + dependents need cpp-httplib, which conda-forge does not ship
+  # for ARM (osx-arm64 / linux-aarch64) — see conda-forge/cpp-httplib-feedstock
+  - if: not (aarch64 or arm64)
     then:
       - ros2_medkit_beacon_common
       - ros2_medkit_gateway


### PR DESCRIPTION
## Goal

Add the `ros2_medkit` diagnostic stack to the robostack-jazzy distribution.

## Description

`ros2_medkit` (https://index.ros.org/r/ros2_medkit/) is a structured diagnostic model for ROS 2 robots that exposes faults over a REST/SOVD API. This PR adds the released 0.4.0 packages: the message/service interfaces, the fault manager and detection, the diagnostic/log/action bridges, the REST gateway SOVD plugins.

The dependency `libcpp-httplib-dev` is mapped to the conda-forge `cpp-httplib` package (used by the gateway's REST server).

## Changes

- Added the ros2_medkit packages to the jazzy build selection in `vinca.yaml`.
- Added a rosdep mapping `libcpp-httplib-dev -> cpp-httplib` in `robostack.yaml`.
- Added a patch fixing a `std::vector<bool>` build error in
  `ros2_medkit_serialization` on macOS (see Notes).

## License

`ros2_medkit` is licensed under Apache-2.0 (per the upstream packages).

## Notes

Build tested locally on  osx-arm64.

**macOS (serialization):** `ros2_medkit_serialization` failed to compile on clang/libc++ with:
`error: implicit instantiation of undefined template 'YAML::convert<std::__bit_const_reference<std::vector<bool>>>'`. The vendored `dynmsg` code pushes a `std::vector<bool>::operator[]` proxy directly into a yaml-cpp node; clang has no conversion for that proxy type. Fixed with a one-line patch casting the proxy to `bool` before `push_back` (`patch/ros-jazzy-ros2-medkit-serialization.patch`). This is a genuine upstream bug (present in 0.4.0 through main).