### PR TITLE
Add ntrip_client

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -233,6 +233,8 @@ packages_select_by_deps:
 
   - nmea-navsat-driver
 
+  - ntrip_client
+
   - tracetools
   - tracetools-launch
   - tracetools-trace


### PR DESCRIPTION
Would like to add `ntrip_client`. 

I'm using Jazzy so starting here, but is there a streamlined way to add simple packages that probably backport well? Start with `ros-rolling` instead? Or is it just an individual PR per distro?