### PR TITLE
Bump ur_client_library

### DIFF
--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -7736,9 +7736,9 @@ ur_calibration:
   url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
   version: 3.8.0
 ur_client_library:
-  tag: release/jazzy/ur_client_library/2.11.0-1
+  tag: release/jazzy/ur_client_library/2.12.0-1
   url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-  version: 2.11.0
+  version: 2.12.0
 ur_controllers:
   tag: release/jazzy/ur_controllers/3.8.0-1
   url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git


### PR DESCRIPTION
A small step from `2.11.0` to `2.12.0`. To reduce risk of breaking anything, I'll file PRs for `2.13.0` and `2.14.1` later.