### PR TITLE
chore: increase batch size windows builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,8 +101,8 @@ jobs:
         pixi run -v vinca --multiple --platform win-64
     - name: Generate GitHub Actions pipelines for win-64
       run: |
-        # --batch_size 10 is a workaround for https://github.com/RoboStack/robostack.github.io/issues/105
-        pixi run -v vinca-gha --platform win-64 --trigger-branch buildbranch_win -d ./recipes --batch_size 10
+        # --batch_size 20 is a workaround for https://github.com/RoboStack/robostack.github.io/issues/105
+        pixi run -v vinca-gha --platform win-64 --trigger-branch buildbranch_win -d ./recipes --batch_size 20
     - name: Commit files for win-64
       run: |
         if [[ -f "win.yml" ]]; then


### PR DESCRIPTION
This should lower the file size of the windows build github action yaml. Currently it's `528kb` but it should be less then `500`: https://github.com/RoboStack/robostack.github.io/issues/105

I think we should find better ways to generate that file but this unblocks us for now.

