### PR TITLE
fix: ros2 cli autocompletion for bash and zsh

### DIFF
--- a/patch/ros-jazzy-ros2cli.patch
+++ b/patch/ros-jazzy-ros2cli.patch
@@ -1,0 +1,31 @@
+diff --git a/ros2cli/completion/ros2-argcomplete.zsh b/ros2cli/completion/ros2-argcomplete.zsh
+index b9fc309..ad14fbb 100644
+--- a/ros2cli/completion/ros2-argcomplete.zsh
++++ b/ros2cli/completion/ros2-argcomplete.zsh
+@@ -20,6 +20,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __ros2cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__ros2cli_completion_dir/ros2-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"
+ # Cleanup
+ unset __ros2cli_completion_dir
+diff --git a/ros2cli/setup.py b/ros2cli/setup.py
+index f28b689..a0fe44a 100644
+--- a/ros2cli/setup.py
++++ b/ros2cli/setup.py
+@@ -23,6 +23,14 @@ setup(
+             'completion/ros2-argcomplete.bash',
+             'completion/ros2-argcomplete.zsh'
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/ros2-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/ros2-argcomplete.zsh'
++        ]),
+     ],
+     zip_safe=False,
+     author='Dirk Thomas',

--- a/patch/ros-jazzy-rosidl.patch
+++ b/patch/ros-jazzy-rosidl.patch
@@ -1,0 +1,31 @@
+diff --git a/rosidl_cli/completion/rosidl-argcomplete.zsh b/rosidl_cli/completion/rosidl-argcomplete.zsh
+index 9a86dbd..c4a4253 100644
+--- a/rosidl_cli/completion/rosidl-argcomplete.zsh
++++ b/rosidl_cli/completion/rosidl-argcomplete.zsh
+@@ -18,6 +18,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __rosidl_cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__rosidl_cli_completion_dir/rosidl-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"
+ # Cleanup
+ unset __rosidl_cli_completion_dir
+diff --git a/rosidl_cli/setup.py b/rosidl_cli/setup.py
+index 8b1335a..a012273 100644
+--- a/rosidl_cli/setup.py
++++ b/rosidl_cli/setup.py
+@@ -23,6 +23,14 @@ setup(
+             'completion/rosidl-argcomplete.bash',
+             'completion/rosidl-argcomplete.zsh'
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/rosidl-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/rosidl-argcomplete.zsh'
++        ]),
+     ],
+     zip_safe=False,
+     author='Michel Hidalgo',

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -179,7 +179,7 @@ visp:
     override_version: '3.6.0'
 zenoh_cpp_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK -DUSE_SYSTEM_ZENOH=ON"
-rosidl_cli:
-  build_number: 22
 ros2cli:
+  build_number: 22
+rosidl_cli:
   build_number: 22

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -179,3 +179,7 @@ visp:
     override_version: '3.6.0'
 zenoh_cpp_vendor:
   additional_cmake_args: "-DAMENT_VENDOR_POLICY=NEVER_VENDOR_IGNORE_SATISFIED_CHECK -DUSE_SYSTEM_ZENOH=ON"
+rosidl_cli:
+  build_number: 22
+ros2cli:
+  build_number: 22

--- a/tests/ros-jazzy-ros2cli.yaml
+++ b/tests/ros-jazzy-ros2cli.yaml
@@ -1,0 +1,8 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/ros2-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh
+        - grep -q 'source "\$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"' ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh

--- a/tests/ros-jazzy-rosidl.yaml
+++ b/tests/ros-jazzy-rosidl.yaml
@@ -1,0 +1,8 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/rosidl-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh
+        - grep -q 'source "\$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"' ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -10,7 +10,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 22
+# Reminder for next full rebuild, the next build number should be 23
 build_number: 21
 
 mutex_package:


### PR DESCRIPTION
Fixes the ros2cli autocompletion. Based on https://github.com/RoboStack/ros-jazzy/pull/206, but with zsh fixes and resolved conflicts